### PR TITLE
Feature/local chatroom

### DIFF
--- a/Client/src/components/Chat.tsx
+++ b/Client/src/components/Chat.tsx
@@ -1,29 +1,35 @@
-import React from 'react'
-import ChatInput from './ChatInput'
-import { GlobalContext } from '../states'
-import { MessageType } from '../types'
-import { SocketContext } from '../socket'
-import AutoScroll from '@brianmcallister/react-auto-scroll'
+import React from 'react';
+import ChatInput from './ChatInput';
+import { GlobalContext } from '../states';
+import { MessageType } from '../types';
+import { SocketContext } from '../socket';
+import AutoScroll from '@brianmcallister/react-auto-scroll';
 
 export default function Chat() {
-    const { global_state } = React.useContext(GlobalContext)
-    const { chatHistory } = global_state
-    const { socket } = React.useContext(SocketContext)
-    const [ chatHeight, setChatHeight ] = React.useState<number>(0)
-    const chatWindowRef = React.useRef<HTMLDivElement>(null)
+    const { global_state } = React.useContext(GlobalContext);
+    const { chatHistory, name, gameInfo } = global_state;
+    const { socket } = React.useContext(SocketContext);
+    const [ chatHeight, setChatHeight ] = React.useState<number>(0);
+    const chatWindowRef = React.useRef<HTMLDivElement>(null);
     const chatHeightHandler = () => {
         if (chatWindowRef.current !== null) {
-            setChatHeight(chatWindowRef.current.clientHeight)
+            setChatHeight(chatWindowRef.current.clientHeight);
         }
     }
     React.useLayoutEffect(()=>{
-        chatHeightHandler()
-        window.addEventListener('resize',chatHeightHandler)
-        return ()=>window.removeEventListener('resize',chatHeightHandler)
+        chatHeightHandler();
+        window.addEventListener('resize',chatHeightHandler);
+        return ()=>window.removeEventListener('resize',chatHeightHandler);
     },[])
     React.useEffect(()=>{
         if (socket !== undefined) {
-            socket.emit('chat request')
+            //waits for server to load activeUsers first before sending request
+            setTimeout(()=>{
+                socket.emit('chat request',{ 
+                    name:name, 
+                    roomID:gameInfo?.roomID
+                });
+            },500)
         }
     },[socket])
     return (

--- a/Client/src/components/ChatInput.tsx
+++ b/Client/src/components/ChatInput.tsx
@@ -1,21 +1,27 @@
 import React, { FormEvent } from 'react'
 import { SocketContext } from '../socket';
 import { GlobalContext } from '../states';
+import { MessageType } from '../types';
 
 export default function ChatInput() {
-    const { global_state } = React.useContext(GlobalContext)
-    const { socket } = React.useContext(SocketContext)
-    const { name } = global_state
+    const { global_state } = React.useContext(GlobalContext);
+    const { socket } = React.useContext(SocketContext);
+    const { name, gameInfo } = global_state;
     const messageRef = React.useRef<any>(null);
     const handleOnSubmit = (e:FormEvent) => {
-        e.preventDefault()
+        e.preventDefault();
         if (messageRef.current !== null) {
+            const messageObj: MessageType = { 
+                message:messageRef.current.value,
+                from:name,
+                at:Date.now(),
+            }
             socket.emit('chat message',{ 
-                msg:messageRef.current.value,
+                msg:messageObj,
                 name:name,
-                id:socket.id,
+                roomID:gameInfo?.roomID,
             });
-            messageRef.current.value = ""
+            messageRef.current.value = "";
         }
     }
     return (

--- a/Client/src/components/Invite.tsx
+++ b/Client/src/components/Invite.tsx
@@ -13,8 +13,7 @@ export default function Invite() {
     //mode 2 = (sender) gets accepted or decline
     //mode 3 = error occured
     const [ inviteStorage, setInviteStorage ] = React.useState<InviteStorageType>({
-        senderName:"",
-        room_ID:"",
+        senderName:""
     });
     const [ decision, setDecision ] = React.useState<boolean>(false);
     const handleOnClickDecision = (bool:boolean) => {
@@ -24,7 +23,6 @@ export default function Invite() {
             socket.emit("invite reply",{ 
                 senderName:inviteStorage.senderName,
                 receiverName:name,
-                room_ID:inviteStorage.room_ID,
                 decision:bool,
             });
             setMode(0);
@@ -43,7 +41,7 @@ export default function Invite() {
             }:InviteInfoType) => {
                 console.log(senderName, roomID, error)
                 if (error===undefined && senderName!==undefined && roomID!==undefined) {
-                    setInviteStorage({ senderName:senderName, room_ID:roomID });
+                    setInviteStorage({ senderName:senderName });
                     setMode(1);
                 } else {
                     console.log('undefined')

--- a/Client/src/components/Result.tsx
+++ b/Client/src/components/Result.tsx
@@ -24,13 +24,13 @@ export default function Result() {
     }
     const handleOnClickMenu = () => {
         if (socket !== undefined) {
+            socket.emit("leave room request", gameInfo.roomID)
             const newFlags = { ...flags, resultVisible:false }
             dispatch({ 
-                type:"set", 
-                field:"flags", 
-                payload:newFlags
+                type:"multi-set", 
+                field:["flags", "gameInfo"], 
+                payload:[newFlags, []]
             })
-            socket.emit("leave room request", gameInfo.roomID)
             setPlayAgainVisible(true)
             navigate('/menu')
         }

--- a/Client/src/types.ts
+++ b/Client/src/types.ts
@@ -16,7 +16,6 @@ export interface UserType {
 }
 export interface InviteStorageType {
 	senderName:string;
-	room_ID:string;
 }
 export interface InviteInfoType {
 	senderName?:string;

--- a/Server/dist/server.js
+++ b/Server/dist/server.js
@@ -342,11 +342,9 @@ socketIO.on("connection", (socket) => {
         //chat histories are private (different roomID will not have access to each other's chat history)
         console.log("CHAT REQUEST ARG", name, roomID);
         if (activeUsers[name].inGame && roomID !== undefined) {
-            console.log("CHAT HISTORY LOCAL", chatHistory.local[roomID]);
             socketIO.to(roomID).emit("chat update", chatHistory.local[roomID]);
         }
         else {
-            console.log(chatHistory.global);
             socketIO.to("global").emit("chat update", chatHistory.global);
         }
     });

--- a/Server/dist/server.js
+++ b/Server/dist/server.js
@@ -274,7 +274,7 @@ socketIO.on("connection", (socket) => {
             roomID: roomID,
         });
     });
-    socket.on("invite reply", ({ senderName, receiverName, room_ID, decision }) => {
+    socket.on("invite reply", ({ senderName, receiverName, decision }) => {
         //remove any expired invitation (by timeout)
         removeExpiredInvitation();
         //get the most recent invitation of sender and receiver 

--- a/Server/dist/server.js
+++ b/Server/dist/server.js
@@ -35,7 +35,7 @@ const chooseRandomUser = () => {
 const generateID = () => {
     return uuid.v4();
 };
-const generateGameInfo = (gameInfos, counters, chatHistory, roomID) => {
+const generateGameInfo = (roomID) => {
     const id = roomID !== undefined ? roomID : generateID();
     const newGameInfo = {
         roomID: id,
@@ -65,7 +65,8 @@ const resetRoom = (roomID) => {
 };
 const removeRoom = (roomID) => {
     gameInfos = gameInfos.filter((gameInfo) => gameInfo.roomID !== roomID);
-    console.log("REMOVED ROOM", gameInfos);
+    delete chatHistory.local[roomID];
+    console.log("REMOVED ROOM", roomID);
 };
 const resetCountdown = (info, roomID) => {
     const counter = getCounter(roomID);
@@ -87,7 +88,7 @@ const getGameInfo = (roomID) => {
 const getCounter = (roomID) => {
     return counters.find((counterObj) => counterObj.roomID === roomID);
 };
-const removeRoomUser = (user, callback) => {
+const removeUser = (user, callback) => {
     let info = gameInfos.find((infoObj) => {
         if (infoObj.scores[0] + infoObj.scores[1] !== WINNING_SCORE) {
             return infoObj.users.find((userObj) => userObj.name === user.name) !== undefined;
@@ -105,7 +106,15 @@ const removeRoomUser = (user, callback) => {
     }
 };
 const cleanGameInfos = () => {
-    gameInfos = gameInfos.filter((gameInfo) => gameInfo.scores[0] + gameInfo.scores[1] !== WINNING_SCORE);
+    gameInfos = gameInfos.filter((gameInfo) => {
+        if (gameInfo.scores[0] + gameInfo.scores[1] === WINNING_SCORE) {
+            delete chatHistory.local[gameInfo.roomID];
+            return false;
+        }
+        else {
+            return true;
+        }
+    });
     console.log('cleared unused rooms', gameInfos);
 };
 const switchUser = (roomID) => {
@@ -125,10 +134,10 @@ const removeExpiredInvitation = () => {
         .filter((key) => compareAsc(Date.now(), invitation[key].validUntil) === 1 ? true : false);
     console.log("EXPIRED_KEYS", expiredKeys);
     expiredKeys.forEach((key) => {
-        //removes the room that is created as well if room doesn't have 2 people
         const roomID = invitation[key].roomID;
         const info = getGameInfo(roomID);
         console.log("INFO USER LENGTH AUTO EXPIRE", info.users);
+        //removes the room that is created as well if room doesn't have 2 people
         if (info.users.length < 2)
             removeRoom(roomID);
         delete invitation[key];
@@ -143,6 +152,7 @@ const expireInvitation = (senderName) => {
             const roomID = invitation[key].roomID;
             const info = getGameInfo(roomID);
             console.log("INFO USER LENGTH MANUAL EXPIRE", info.users);
+            //removes the room that is created as well if room doesn't have 2 people
             if (info.users.length < 2)
                 removeRoom(roomID);
             delete invitation[key];
@@ -249,12 +259,12 @@ socketIO.on("connection", (socket) => {
             }
             console.log("full rooms, creating new room...");
             cleanGameInfos();
-            generateGameInfo(gameInfos, counters, chatHistory);
+            generateGameInfo();
         }
     });
     socket.on("unmatching", (user) => {
         console.log("Unmatching request", user);
-        removeRoomUser(user, (roomID) => socket.leave(roomID));
+        removeUser(user, (roomID) => socket.leave(roomID));
     });
     socket.on("invite request", ({ senderName, receiverName }) => {
         const roomID = generateID();
@@ -265,7 +275,7 @@ socketIO.on("connection", (socket) => {
             validUntil: addSeconds(Date.now(), 15)
         });
         console.log("INVITATION", invitation);
-        const info = generateGameInfo(gameInfos, counters, chatHistory, roomID);
+        const info = generateGameInfo(roomID);
         info.users.push(activeUsers[senderName]);
         socket.join(roomID);
         socket.leave("global");
@@ -307,7 +317,6 @@ socketIO.on("connection", (socket) => {
                 console.log('request from', senderName, 'declined by', receiverName, socket.id);
                 //tear down room because invitation was declined
                 socketIO.socketsLeave(roomID);
-                expireInvitation(senderName);
             }
             cleanGameInfos();
         }
@@ -331,10 +340,13 @@ socketIO.on("connection", (socket) => {
     socket.on("chat request", ({ name, roomID }) => {
         //server selects and sends the chat history according to user status (online or in-game)
         //chat histories are private (different roomID will not have access to each other's chat history)
+        console.log("CHAT REQUEST ARG", name, roomID);
         if (activeUsers[name].inGame && roomID !== undefined) {
+            console.log("CHAT HISTORY LOCAL", chatHistory.local[roomID]);
             socketIO.to(roomID).emit("chat update", chatHistory.local[roomID]);
         }
         else {
+            console.log(chatHistory.global);
             socketIO.to("global").emit("chat update", chatHistory.global);
         }
     });

--- a/Server/dist/server.js
+++ b/Server/dist/server.js
@@ -336,6 +336,7 @@ socketIO.on("connection", (socket) => {
         else {
             selectedChatHistory = chatHistory.global;
         }
+        console.log("CHAT HISTORY REQUEST", selectedChatHistory, roomID);
         socketIO.emit("chat update", selectedChatHistory);
     });
     socket.on("select block", ({ index, roomID }) => {

--- a/Server/server.ts
+++ b/Server/server.ts
@@ -301,9 +301,9 @@ socketIO.on("connection", (socket:any)=>{
         });
     });
     socket.on("invite reply",({
-        senderName, receiverName, room_ID, decision
+        senderName, receiverName, decision
     }:{
-        senderName:string, receiverName:string, room_ID:string, decision:boolean
+        senderName:string, receiverName:string, decision:boolean
     })=>{
         //remove any expired invitation (by timeout)
         removeExpiredInvitation();

--- a/Server/server.ts
+++ b/Server/server.ts
@@ -370,6 +370,7 @@ socketIO.on("connection", (socket:any)=>{
         } else {
             selectedChatHistory = chatHistory.global;
         }
+        console.log("CHAT HISTORY REQUEST",selectedChatHistory,roomID)
         socketIO.emit("chat update", selectedChatHistory);
     });
     socket.on("select block", ({

--- a/Server/server.ts
+++ b/Server/server.ts
@@ -371,10 +371,8 @@ socketIO.on("connection", (socket:any)=>{
         //chat histories are private (different roomID will not have access to each other's chat history)
         console.log("CHAT REQUEST ARG", name, roomID)
         if (activeUsers[name].inGame && roomID !== undefined) {
-            console.log("CHAT HISTORY LOCAL", chatHistory.local[roomID])
             socketIO.to(roomID).emit("chat update", chatHistory.local[roomID]);
         } else {
-            console.log(chatHistory.global)
             socketIO.to("global").emit("chat update", chatHistory.global);
         }
     });


### PR DESCRIPTION
Main changes:
- implemented new chat history structure (local and global chat rooms)
- fixed an invitation bug (in multi-invite case where 2nd user got expired after 1st user declined)

Details:
- added a new "global" room (joins whenever user is in online state, leaves when in-game)
- removed unused roomID argument when sending back reply
- gameInfo value (client) is cleared when the game is over and user has left the room (this is to allow roomID to become undefined naturally before sending to server when requesting chat since chat request needs to send correct chat history according to user status)
- cleaning of chat history alongside room removal
- chat message object is  now created at the client (previously created at server)
- generateGameInfo (server) now only requires roomID (optional)