### PR TITLE
Feature/minor chat fix

### DIFF
--- a/Server/dist/server.js
+++ b/Server/dist/server.js
@@ -60,7 +60,7 @@ const resetRoom = (roomID) => {
     const info = getGameInfo(roomID);
     if (info !== undefined) {
         info.timer = 10;
-        info.playingUser = chooseRandomUser();
+        info.playingUser = info.scores[0] > info.scores[1] ? 0 : 1;
         info.scores = [0, 0];
         info.minesArray = createMinesArray();
     }

--- a/Server/dist/server.js
+++ b/Server/dist/server.js
@@ -247,7 +247,6 @@ socketIO.on("connection", (socket) => {
     socket.on("name register", (user) => {
         activeUsers[user.name] = { id: user.id, name: user.name, inGame: user.inGame };
         socketIO.emit("active user update", activeUsers);
-        socket.join("global");
     });
     socket.on("matching", (user) => {
         console.log("Matching request", user);
@@ -258,7 +257,6 @@ socketIO.on("connection", (socket) => {
                     && (info.users.length < 2) && info.type === "matching") {
                     info.users.push(user);
                     socket.join(info.roomID);
-                    socket.leave("global");
                     console.log(gameInfos);
                     return;
                 }
@@ -284,7 +282,6 @@ socketIO.on("connection", (socket) => {
         const info = generateGameInfo("invitation", roomID);
         info.users.push(activeUsers[senderName]);
         socket.join(roomID);
-        socket.leave("global");
         socketIO.to(activeUsers[receiverName].id).emit("request incoming", {
             senderName: senderName,
             roomID: roomID,
@@ -343,7 +340,8 @@ socketIO.on("connection", (socket) => {
         }
         else {
             chatHistory.global.push(msg);
-            socketIO.to("global").emit("chat update", chatHistory.global);
+            socketIO.except(gameInfos.map((gameInfo) => gameInfo.roomID))
+                .emit("chat update", chatHistory.global);
         }
     });
     socket.on("chat request", ({ name, roomID }) => {
@@ -354,7 +352,8 @@ socketIO.on("connection", (socket) => {
             socketIO.to(roomID).emit("chat update", chatHistory.local[roomID]);
         }
         else {
-            socketIO.to("global").emit("chat update", chatHistory.global);
+            socketIO.except(gameInfos.map((gameInfo) => gameInfo.roomID))
+                .emit("chat update", chatHistory.global);
         }
     });
     socket.on("select block", ({ index, roomID }) => {
@@ -383,7 +382,6 @@ socketIO.on("connection", (socket) => {
             socketIO.emit("active user update", activeUsers);
         }
         socket.leave(roomID);
-        socket.join("global");
     });
     socket.on("reconnect game", ({ roomID }) => {
         socket.join(roomID);

--- a/Server/server.ts
+++ b/Server/server.ts
@@ -64,7 +64,7 @@ const resetRoom = (roomID:string) => {
     const info = getGameInfo(roomID);
     if (info !== undefined) {
         info.timer = 10;
-        info.playingUser = chooseRandomUser();
+        info.playingUser = info.scores[0]>info.scores[1]?0:1;
         info.scores = [0,0];
         info.minesArray = createMinesArray();
     }

--- a/Server/server.ts
+++ b/Server/server.ts
@@ -263,7 +263,6 @@ socketIO.on("connection", (socket:any)=>{
     socket.on("name register", (user:UserType)=>{
         activeUsers[user.name] = { id:user.id, name:user.name, inGame:user.inGame };
 		socketIO.emit("active user update", activeUsers);
-        socket.join("global");
     });
     socket.on("matching", (user:UserType)=>{
         console.log("Matching request",user);
@@ -274,7 +273,6 @@ socketIO.on("connection", (socket:any)=>{
                 && (info.users.length < 2) && info.type==="matching") {
                     info.users.push(user);
                     socket.join(info.roomID);
-                    socket.leave("global")
                     console.log(gameInfos);
                     return;
                 }
@@ -304,7 +302,6 @@ socketIO.on("connection", (socket:any)=>{
         const info = generateGameInfo("invitation",roomID);
         info.users.push(activeUsers[senderName]);
         socket.join(roomID);
-        socket.leave("global");
         socketIO.to(activeUsers[receiverName].id).emit("request incoming", {
             senderName:senderName,
             roomID:roomID,
@@ -368,7 +365,8 @@ socketIO.on("connection", (socket:any)=>{
             socketIO.to(roomID).emit("chat update", chatHistory.local[roomID]);
         } else {
             chatHistory.global.push(msg);
-            socketIO.to("global").emit("chat update", chatHistory.global);
+            socketIO.except(gameInfos.map((gameInfo:GameInfoType)=>gameInfo.roomID))
+                .emit("chat update", chatHistory.global);
         }
     });
     socket.on("chat request", ({
@@ -382,7 +380,8 @@ socketIO.on("connection", (socket:any)=>{
         if (activeUsers[name].inGame && roomID !== undefined) {
             socketIO.to(roomID).emit("chat update", chatHistory.local[roomID]);
         } else {
-            socketIO.to("global").emit("chat update", chatHistory.global);
+            socketIO.except(gameInfos.map((gameInfo:GameInfoType)=>gameInfo.roomID))
+                .emit("chat update", chatHistory.global);
         }
     });
     socket.on("select block", ({
@@ -416,7 +415,6 @@ socketIO.on("connection", (socket:any)=>{
 		    socketIO.emit("active user update", activeUsers);
         }
 		socket.leave(roomID);
-        socket.join("global");
     })
     socket.on("reconnect game",({ roomID }:{ roomID:string })=>{
         socket.join(roomID);


### PR DESCRIPTION
Main changes:
- fixed global chat/local chat not loading properly
- first player is now winner of the previous round (in rematch only)

Details:
- removed "global" room, emit.to(global) -> emit.except(roomIDs) (reason is because consecutive join and leave calls sometimes can't keep up, which leaves some users out of the global room)
- resetRoom function chooses first player according to their previous score