### PR TITLE
Feature/personal color

### DIFF
--- a/Client/src/components/ActiveUsers.tsx
+++ b/Client/src/components/ActiveUsers.tsx
@@ -24,7 +24,7 @@ export default function ActiveUsers() {
 	return (
 		<div className='flex-1 overflow-y-scroll'>
 			<div className='flex flex-col text-xl'>
-				{priorities.map((user: UserType) => {
+				{priorities.map((user: PriorityType) => {
 					return (
 						<div
 							className={` flex justify-between ${

--- a/Client/src/components/ActiveUsers.tsx
+++ b/Client/src/components/ActiveUsers.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { getUserColor } from "../lib/utility/GetUserColor";
 import { GlobalContext } from "../states";
 import { PriorityType, UserType } from "../types";
 import InviteButton from "./InviteButton";
@@ -29,15 +30,25 @@ export default function ActiveUsers() {
 						<div
 							className={` flex justify-between ${
 								user.inGame ? "text-yellow-400" : "text-green-400"
-							} p-2 bg-neutral-800 rounded-full my-2 shadow-md`}
+							} p-2 rounded-full my-2 shadow-lg bg-neutral-800`}
+							style={{
+								background:`linear-gradient(360deg, ${getUserColor(activeUsers,user.name)} 3%, rgb(40,40,40) 5%)`
+							}}
 						>
 							<div
 								className={`h-4 w-4 ${
 									user.inGame ? "bg-yellow-400" : "bg-green-400"
 								} rounded-full my-auto mr-2`}
 							/>
-							<div className="my-auto">{user.name.toString()}</div>
-							<div className="my-auto">{user.inGame ? "In-Game" : "Online"}</div>
+							<div 
+								style={{
+									color:getUserColor(activeUsers,user.name)
+								}}
+								className="font-righteous my-auto brightness-125 text-xl"
+							>
+								{user.name.toString().toUpperCase()}
+							</div>
+							<div className="my-auto text-lg">{user.inGame ? "IN-GAME" : "ONLINE"}</div>
 							<InviteButton user={user} />
 						</div>
 					);

--- a/Client/src/components/ActiveUsers.tsx
+++ b/Client/src/components/ActiveUsers.tsx
@@ -30,9 +30,9 @@ export default function ActiveUsers() {
 						<div
 							className={` flex justify-between ${
 								user.inGame ? "text-yellow-400" : "text-green-400"
-							} p-2 rounded-full my-2 shadow-lg bg-neutral-800`}
+							} p-2 rounded-full my-2 shadow-lg bg-neutral-800 border-[1px]`}
 							style={{
-								background:`linear-gradient(360deg, ${getUserColor(activeUsers,user.name)} 3%, rgb(40,40,40) 5%)`
+								borderColor:getUserColor(activeUsers,user.name)
 							}}
 						>
 							<div
@@ -44,7 +44,7 @@ export default function ActiveUsers() {
 								style={{
 									color:getUserColor(activeUsers,user.name)
 								}}
-								className="font-righteous my-auto brightness-125 text-xl"
+								className="my-auto brightness-125 text-xl"
 							>
 								{user.name.toString().toUpperCase()}
 							</div>

--- a/Client/src/components/Chat.tsx
+++ b/Client/src/components/Chat.tsx
@@ -59,7 +59,7 @@ export default function Chat() {
                                     color:getUserColor(activeUsers,msg.from)
                                 }}
                             >
-                                <div className="flex">
+                                <div className="flex brightness-125">
                                     <div>{msg.from}:</div>
                                     <div className="ml-3">
                                         {msg.message}

--- a/Client/src/components/Chat.tsx
+++ b/Client/src/components/Chat.tsx
@@ -4,10 +4,16 @@ import { GlobalContext } from '../states';
 import { MessageType } from '../types';
 import { SocketContext } from '../socket';
 import AutoScroll from '@brianmcallister/react-auto-scroll';
+import { getUserColor } from '../lib/utility/GetUserColor';
 
 export default function Chat() {
     const { global_state } = React.useContext(GlobalContext);
-    const { chatHistory, name, gameInfo } = global_state;
+    const { 
+        chatHistory, 
+        name, 
+        gameInfo,
+        activeUsers
+    } = global_state;
     const { socket } = React.useContext(SocketContext);
     const [ chatHeight, setChatHeight ] = React.useState<number>(0);
     const chatWindowRef = React.useRef<HTMLDivElement>(null);
@@ -33,7 +39,9 @@ export default function Chat() {
         }
     },[socket])
     return (
-        <div className="flex flex-col justify-evenly font-quicksand text-white text-xl h-full">
+        <div 
+            className={`flex flex-col justify-evenly font-quicksand text-xl h-full`}
+        >
             <div
                 ref={chatWindowRef}
                 className="basis-[95%] bg-neutral-800 rounded-3xl mb-5 shadow-md overflow-hidden"
@@ -47,6 +55,9 @@ export default function Chat() {
                             <div 
                                 key={index}
                                 className="flex justify-between px-5 py-1"
+                                style={{
+                                    color:getUserColor(activeUsers,msg.from)
+                                }}
                             >
                                 <div className="flex">
                                     <div>{msg.from}:</div>

--- a/Client/src/components/Chat.tsx
+++ b/Client/src/components/Chat.tsx
@@ -5,6 +5,7 @@ import { MessageType } from '../types';
 import { SocketContext } from '../socket';
 import AutoScroll from '@brianmcallister/react-auto-scroll';
 import { getUserColor } from '../lib/utility/GetUserColor';
+import format from 'date-fns/format';
 
 export default function Chat() {
     const { global_state } = React.useContext(GlobalContext);
@@ -54,18 +55,20 @@ export default function Chat() {
                         return (
                             <div 
                                 key={index}
-                                className="flex justify-between px-5 py-1"
+                                className="flex justify-between px-5 py-1 text-neutral-400"
                                 style={{
                                     color:getUserColor(activeUsers,msg.from)
                                 }}
                             >
                                 <div className="flex brightness-125">
-                                    <div>{msg.from}:</div>
+                                    <div className="">{msg.from.toUpperCase()}:</div>
                                     <div className="ml-3">
                                         {msg.message}
                                     </div>
                                 </div>
-                                <div className="text-green-300">{new Date(msg.at).toLocaleTimeString()}</div>
+                                <div className="text-green-300">
+                                    {format(new Date(msg.at),'HH:mm')}
+                                </div>
                             </div>
                         )
                     })}

--- a/Client/src/components/FoundMineEffect.tsx
+++ b/Client/src/components/FoundMineEffect.tsx
@@ -61,8 +61,7 @@ export default function FoundMineEffect({ minesType, trigger }:FoundMineEffectPr
     React.useEffect(()=>{
         if (visible) {
             setTimeout(()=>setTransition(true),100);
-        } else {
-            setTimeout(()=>setTransition(false),100);
+            setTimeout(()=>setTransition(false),1400);
         }
     },[visible])
     return (

--- a/Client/src/components/InviteButton.tsx
+++ b/Client/src/components/InviteButton.tsx
@@ -2,11 +2,11 @@ import React from 'react'
 import { playAudio } from '../lib/utility/Audio';
 import { SocketContext } from '../socket'
 import { GlobalContext } from '../states'
-import { UserType } from '../types'
+import { PriorityType, UserType } from '../types'
 import Countdown from './Countdown';
 
 interface InviteButtonPropsType {
-    user:UserType;
+    user:PriorityType;
 }
 
 export default function InviteButton({ user }:InviteButtonPropsType) {

--- a/Client/src/components/InviteButton.tsx
+++ b/Client/src/components/InviteButton.tsx
@@ -46,7 +46,7 @@ export default function InviteButton({ user }:InviteButtonPropsType) {
         <div className="relative">
             <div className={`font-righteous absolute ${trigger?"-translate-x-11":"translate-x-0"}  text-lg
             left-0 top-0 h-full p-1 pr-16 text-white ${checkCanInvite()?"bg-green-600":"opacity-0"} 
-            text-center z-10 w-full rounded-full transition-transform duration-100`}>
+            text-center z-10 w-full rounded-full transition-transform duration-100 shadow-md`}>
                 <Countdown
                     seconds={15}
                     trigger={trigger}

--- a/Client/src/components/MinesGrid.tsx
+++ b/Client/src/components/MinesGrid.tsx
@@ -64,13 +64,16 @@ function Block({ block, index }:{ block:BlockType, index:number }) {
                         "hover:bg-gradient-to-t from-cyan-500 to-pink-500":
                         "hover:opacity-60"
                     }
-                    ${block.selected?"bg-opacity-50 bg-white":"bg-slate-700 hover:scale-110"} 
+                    ${block.selectedBy===""?null:
+                    block.selectedBy===name?"border-[0.5px] scale-110 brightness-125 bg-opacity-60":
+                    "brightness-50"}
+                    ${block.selected?"bg-opacity-50 bg-neutral-400":"bg-slate-700 hover:scale-110"} 
                     transition rounded-md shadow-lg`}
             >
                 {block.value === 1 && block.selected &&
                     <Image 
                         type={block.type as string} 
-                        className="animate-spin-slow"
+                        className="animate-spin-slow drop-shadow-md"
                     />
                 }
             </button>

--- a/Client/src/components/MinesGrid.tsx
+++ b/Client/src/components/MinesGrid.tsx
@@ -5,6 +5,7 @@ import { BlockType } from '../types'
 import { SocketContext } from '../socket'
 import Image from './Image'
 import FoundMineEffect from './FoundMineEffect'
+import { getUserColor } from '../lib/utility/GetUserColor'
 
 export default function MinesGrid() {
     const { global_state } = React.useContext(GlobalContext)
@@ -15,7 +16,8 @@ export default function MinesGrid() {
     }
     return (
         <div className={`w-fit grid grid-cols-6 gap-2 m-auto p-5 rounded-3xl transition duration-500
-        ${checkPlayerCanInteract()?"bg-gradient-to-r from-teal-300 to-sky-300":"bg-neutral-500 bg-opacity-70"}`}>
+        ${checkPlayerCanInteract()?"bg-gradient-to-r from-neutral-200 to-neutral-200":
+        "bg-neutral-500 bg-opacity-70"}`}>
             {gameInfo.minesArray.map(
                 (block:BlockType,index:number)=>{
                     return <Block block={block} index={index} />
@@ -28,7 +30,7 @@ export default function MinesGrid() {
 function Block({ block, index }:{ block:BlockType, index:number }) {
     const { global_state } = React.useContext(GlobalContext);
     const { socket } = React.useContext(SocketContext);
-    const { gameInfo, name } = global_state;
+    const { gameInfo, name, activeUsers } = global_state;
     const handleOnClick = () => {
         if (socket !== undefined) {
             socket.emit('select block',{ 
@@ -59,14 +61,17 @@ function Block({ block, index }:{ block:BlockType, index:number }) {
             <button
                 disabled={block.selected || !checkPlayerCanInteract()}
                 onClick={handleOnClick}
+                style={{
+                    backgroundColor:getUserColor(activeUsers,block.selectedBy)
+                }}
                 className={`flex h-20 w-20 gap-2 transition duration-400 
                     ${!block.selected && checkPlayerCanInteract()?
-                        "hover:bg-gradient-to-t from-cyan-500 to-pink-500":
+                        "hover:bg-gradient-to-t from-cyan-400 to-pink-400":
                         "hover:opacity-60"
                     }
                     ${block.selectedBy===""?null:
-                    block.selectedBy===name?"border-[0.5px] scale-110 brightness-125 bg-opacity-60":
-                    "brightness-50"}
+                    block.selectedBy===name?"border-[0.5px] border-black scale-110 brightness-110 bg-opacity-60":
+                    "brightness-75"}
                     ${block.selected?"bg-opacity-50 bg-neutral-400":"bg-slate-700 hover:scale-110"} 
                     transition rounded-md shadow-lg`}
             >

--- a/Client/src/components/MinesGrid.tsx
+++ b/Client/src/components/MinesGrid.tsx
@@ -31,7 +31,11 @@ function Block({ block, index }:{ block:BlockType, index:number }) {
     const { gameInfo, name } = global_state;
     const handleOnClick = () => {
         if (socket !== undefined) {
-            socket.emit('select block',{ index:index, roomID:gameInfo.roomID });
+            socket.emit('select block',{ 
+                index:index, 
+                roomID:gameInfo.roomID,
+                name:name
+            });
             playAudio('dig.wav');
             if (block.value === 1) {
                 setTimeout(()=>playAudio("found.wav"),300);
@@ -46,7 +50,7 @@ function Block({ block, index }:{ block:BlockType, index:number }) {
     }
     return (
         <div className="relative">
-            {block.value === 1 && block.selected &&
+            {block.value === 1 && block.selected && block.selectedBy===name &&
                 <FoundMineEffect 
                     minesType={block.type} 
                     trigger={block.selected}

--- a/Client/src/components/ReplyReceiver.tsx
+++ b/Client/src/components/ReplyReceiver.tsx
@@ -48,7 +48,7 @@ export default function ReplyReceiver() {
                 <button 
                     onClick={handleOnClickClose}
                     className="absolute -top-1 -left-1 w-10 h-10 bg-neutral-500
-                    text-center rounded-full font-righteous shadow-md"
+                    text-center rounded-full font-righteous shadow-md hover:scale-110 transition"
                 >
                     X
                 </button>

--- a/Client/src/components/UserScore.tsx
+++ b/Client/src/components/UserScore.tsx
@@ -1,9 +1,12 @@
 import React from 'react'
+import { UserType } from '../types';
+import { getUserColor } from '../lib/utility/GetUserColor'
 
 interface UserScorePropsType {
     name:string;
     score:number;
     isPlaying:boolean;
+    activeUsers:Array<UserType>
     className?:string;
 }
 
@@ -11,11 +14,14 @@ export default function UserScore({
     name,
     score, 
     isPlaying,
-    className
+    className,
+    activeUsers,
 }:UserScorePropsType) {
     return (
-        <div className={`text-2xl text-white bg-gradient-to-l w-[70%] py-3 m-auto rounded-full
-        ${isPlaying?"from-pink-500 to-cyan-500":"bg-neutral-500"} shadow-md ${className} `}>
+        <div 
+            className={`text-2xl text-white bg-gradient-to-l w-[70%] py-3 m-auto rounded-full
+            ${isPlaying?"from-pink-500 to-cyan-500":"bg-neutral-500"} shadow-md ${className} `}
+        >
             {name.toUpperCase()}'S SCORE : {score}
         </div>
     )

--- a/Client/src/lib/utility/GetUserColor.tsx
+++ b/Client/src/lib/utility/GetUserColor.tsx
@@ -1,0 +1,6 @@
+import { UserType } from "../../types";
+
+export const getUserColor = (activeUsers:Array<UserType>, name:string) => {
+    const userInfo = activeUsers.find((user:UserType)=>user.name===name);
+    return userInfo?.color;
+}

--- a/Client/src/pages/Game.tsx
+++ b/Client/src/pages/Game.tsx
@@ -6,10 +6,11 @@ import { GlobalContext } from '../states'
 import SocketID from '../components/SocketID'
 import Backdrop from '../components/Backdrop'
 import UserScore from '../components/UserScore'
+import { getUserColor } from '../lib/utility/GetUserColor'
 
 export default function Game() {
     const { global_state } = React.useContext(GlobalContext)
-    const { gameInfo, name } = global_state
+    const { gameInfo, name, activeUsers } = global_state
     const { 
         users,
         scores,
@@ -18,7 +19,7 @@ export default function Game() {
     } = gameInfo
     return (
         <div className="flex flex-col h-screen overflow-hidden text-center font-quicksand 
-        bg-gradient-to-t from-transparent to-slate-600">
+        bg-gradient-to-t from-transparent to-slate-700">
             <div className="absolute top-0 botom-0 left-0 right-0 -z-10 bg-cover blur-sm
             bg-[url('../public/assets/images/bg.png')] flex-1 h-screen opacity-50"/>
             <Result />
@@ -26,23 +27,35 @@ export default function Game() {
             <div className="flex-1 flex justify-evenly p-2">
                 <div className="flex basis-[30%] h-[70vh] m-auto">
                     <div className="w-full m-auto">
-                        <div className="text-4xl text-white
-                        w-[70%] rounded-2xl mb-10 mx-auto">
+                        <div 
+                            className={`text-4xl text-white p-2 drop-shadow-md
+                            w-[70%] rounded-3xl mb-10 mx-auto`}
+                            style={{
+                                color:getUserColor(activeUsers,name),
+                            }}
+                        >
                             {name.toUpperCase()}
                         </div>
                         <UserScore 
                             name={users[0].name} 
                             score={scores[0]} 
                             isPlaying={playingUser===0?true:false}
+                            activeUsers={activeUsers}
                             className="my-3"
                         />
                         <UserScore 
                             name={users[1].name} 
                             score={scores[1]} 
                             isPlaying={playingUser===1?true:false}
+                            activeUsers={activeUsers}
                             className="my-3"
                         />
-                        <div className="font-righteous text-5xl text-white p-5">
+                        <div 
+                            style={{
+                                color:getUserColor(activeUsers,users[playingUser].name),
+                            }}
+                            className="font-righteous text-5xl text-white p-5 drop-shadow-md"
+                        >
                             TIMER: {timer}
                         </div>
                         <img
@@ -56,7 +69,7 @@ export default function Game() {
                     <MinesGrid />
                 </div>
                 <div className="flex basis-[30%] h-[70vh] m-auto">
-                    <div className="w-[90%] h-full bg-neutral-500 bg-opacity-70 p-5 rounded-3xl m-auto">
+                    <div className="w-[90%] h-full bg-zinc-600 bg-opacity-70 p-5 rounded-3xl m-auto">
                         <Chat />
                     </div>
                 </div>

--- a/Client/src/pages/Menu.tsx
+++ b/Client/src/pages/Menu.tsx
@@ -21,7 +21,7 @@ export default function Menu() {
                         ONLINE USERS
                     </div>
                     <div className="flex flex-col h-full justify-evenly shadow-md
-                    bg-neutral-600 bg-opacity-80 p-5 rounded-3xl">
+                    bg-zinc-600 bg-opacity-80 p-5 rounded-3xl">
                         <ActiveUsers />
                         <div className="flex py-2">
                         <MatchingButton />
@@ -32,7 +32,7 @@ export default function Menu() {
                     <div className="text-3xl font-righteous text-white w-full text-center mb-2">
                         CHAT
                     </div>
-                    <div className="h-full bg-neutral-600 bg-opacity-80 p-5 rounded-3xl shadow-md">
+                    <div className="h-full bg-zinc-600 bg-opacity-80 p-5 rounded-3xl shadow-md">
                         <Chat />
                     </div>
                 </div>

--- a/Client/src/pages/Menu.tsx
+++ b/Client/src/pages/Menu.tsx
@@ -9,7 +9,7 @@ import SocketID from '../components/SocketID';
 export default function Menu() {
     return (
         <div className="flex flex-col h-screen overflow-hidden text-center font-quicksand
-        bg-gradient-to-t from-transparent to-slate-600">
+        bg-gradient-to-t from-transparent to-slate-700">
             <div className="absolute top-0 botom-0 left-0 right-0 -z-10 bg-cover blur-sm
             bg-[url('../public/assets/images/bg.png')] flex-1 h-screen opacity-50"/>
             <RequestReceiver />

--- a/Client/src/pages/Name.tsx
+++ b/Client/src/pages/Name.tsx
@@ -19,7 +19,7 @@ export default function Name() {
         }
     }
     return (
-        <div className="flex bg-gradient-to-t from-transparent to-slate-600 w-full h-screen p-5">
+        <div className="flex bg-gradient-to-t from-transparent to-slate-700 w-full h-screen p-5">
             <div className="absolute top-0 botom-0 left-0 right-0 -z-10 bg-cover blur-sm
             bg-[url('../public/assets/images/bg.png')] flex-1 h-screen opacity-50"/>
             <form className="flex flex-col m-auto p-2">

--- a/Client/src/socket.tsx
+++ b/Client/src/socket.tsx
@@ -74,12 +74,20 @@ export const SocketProvider = ({ children }: { children: React.ReactNode }) => {
 				});
 			});
 			socket.on("end game", (gameInfo: GameInfoType) => {
-				const newFlags = { ...flags, resultVisible: true };
 				dispatch({
-					type: "multi-set",
-					field: ["gameInfo", "flags"],
-					payload: [gameInfo, newFlags],
+					type: "set",
+					field: "gameInfo",
+					payload: gameInfo,
 				});
+				//delay showing results (to allow users to see last mine first)
+				setTimeout(()=>{
+					const newFlags = { ...flags, resultVisible: true };
+					dispatch({
+						type: "set",
+						field: "flags",
+						payload: newFlags,
+					})
+				},2000)
 			});
 			socket.on("other user left", () => {
 				const newFlags = { 

--- a/Client/src/types.ts
+++ b/Client/src/types.ts
@@ -8,6 +8,7 @@ export interface MessageType {
 export interface BlockType {
 	selected: boolean;
 	value: number;
+	selectedBy: string;
 	type: string | null;
 }
 export interface UserType {

--- a/Client/src/types.ts
+++ b/Client/src/types.ts
@@ -15,6 +15,7 @@ export interface UserType {
 	name: string;
 	id: string;
 	inGame: boolean;
+	color: string;
 }
 export interface InviteStorageType {
 	senderName:string;

--- a/Server/dist/server.js
+++ b/Server/dist/server.js
@@ -23,10 +23,12 @@ const createMinesArray = () => {
             {
                 selected: false,
                 value: 1,
+                selectedBy: "",
                 type: types[index],
             } : {
             selected: false,
             value: 0,
+            selectedBy: "",
             type: null,
         };
     });
@@ -394,9 +396,10 @@ socketIO.on("connection", (socket) => {
                 .emit("chat update", chatHistory.global);
         }
     });
-    socket.on("select block", ({ index, roomID }) => {
+    socket.on("select block", ({ index, roomID, name }) => {
         const info = getGameInfo(roomID);
         info.minesArray[index].selected = true;
+        info.minesArray[index].selectedBy = name;
         if (info.minesArray[index].value === 1) {
             let score = 0;
             switch (info.minesArray[index].type) {

--- a/Server/dist/server.js
+++ b/Server/dist/server.js
@@ -7,6 +7,7 @@ const socketIO = require("socket.io")(http, {
         origin: "*"
     }
 });
+const Please = require("pleasejs");
 const addSeconds = require("date-fns/addSeconds");
 const compareAsc = require("date-fns/compareAsc");
 const WINNING_SCORE = 2100;
@@ -51,6 +52,9 @@ const generateTypesIndexesFrom = (amountArray, arr) => {
 };
 const getRandomInt = (min, max) => {
     return Math.round(Math.random() * (max - min) + min);
+};
+const getUserColor = () => {
+    return Please.make_color();
 };
 const chooseRandomUser = () => {
     return Math.random() > 0.5 ? 1 : 0;
@@ -280,7 +284,12 @@ socketIO.of("/").adapter.on("leave-room", (roomID, id) => {
 socketIO.on("connection", (socket) => {
     console.log("Connected!", socket.id, socketIO.of("/").sockets.size);
     socket.on("name register", (user) => {
-        activeUsers[user.name] = { id: user.id, name: user.name, inGame: user.inGame };
+        activeUsers[user.name] = {
+            id: user.id,
+            name: user.name,
+            inGame: user.inGame,
+            color: getUserColor(),
+        };
         socketIO.emit("active user update", activeUsers);
     });
     socket.on("matching", (user) => {

--- a/Server/server.ts
+++ b/Server/server.ts
@@ -7,6 +7,7 @@ const socketIO = require("socket.io")(http,{
       origin: "*"
     }
 });
+const Please = require("pleasejs")
 const addSeconds = require("date-fns/addSeconds");
 const compareAsc = require("date-fns/compareAsc");
 
@@ -54,6 +55,9 @@ const generateTypesIndexesFrom = (amountArray:Array<number>, arr:Array<number>) 
 const getRandomInt = (min:number, max:number) => {
     return Math.round(Math.random() * (max - min) + min);
 };
+const getUserColor = () => {
+    return Please.make_color();
+}
 const chooseRandomUser = () => {
     return Math.random()>0.5?1:0;
 };
@@ -294,7 +298,12 @@ socketIO.of("/").adapter.on("leave-room",(roomID:string,id:string) => {
 socketIO.on("connection", (socket:any)=>{
     console.log("Connected!",socket.id, socketIO.of("/").sockets.size);
     socket.on("name register", (user:UserType)=>{
-        activeUsers[user.name] = { id:user.id, name:user.name, inGame:user.inGame };
+        activeUsers[user.name] = { 
+            id:user.id, 
+            name:user.name, 
+            inGame:user.inGame,
+            color:getUserColor(),
+        };
 		socketIO.emit("active user update", activeUsers);
     });
     socket.on("matching", (user:UserType)=>{
@@ -519,6 +528,7 @@ interface UserType {
     name:string;
     id:string;
     inGame:boolean;
+    color:string;
 }
 interface GameInfoType {
     roomID:string;

--- a/Server/server.ts
+++ b/Server/server.ts
@@ -24,10 +24,12 @@ const createMinesArray = () => {
             {
                 selected:false,
                 value:1,
+                selectedBy:"",
                 type:types[index],
             }:{
                 selected:false,
                 value:0,
+                selectedBy:"",
                 type:null,
             };
         
@@ -423,12 +425,13 @@ socketIO.on("connection", (socket:any)=>{
         }
     });
     socket.on("select block", ({
-        index, roomID
+        index, roomID, name
     }:{
-        index:number, roomID:string
+        index:number, roomID:string, name:string
     })=>{
         const info = getGameInfo(roomID) 
         info.minesArray[index].selected = true;
+        info.minesArray[index].selectedBy = name;
         if (info.minesArray[index].value === 1) {
             let score = 0;
             switch (info.minesArray[index].type) {
@@ -509,6 +512,7 @@ interface MessageType {
 interface BlockType {
     selected:boolean;
     value:number;
+    selectedBy:string;
     type:string | undefined;
 }
 interface UserType {


### PR DESCRIPTION
Main changes:
- added personal colors by randomization (purpose is to differentiate actions taken between users)
   1. colored chat
   2. colored active users list
   3. colored blocks selected (shows a user's selected path)
   4. colored timer (to signify a player's turn as well)
   5. colored name (in-game)
- fixed a bug where the game doesn't start when a player sent 2 invite and the first player accepted

Details:
- added new library (pleaseJS) to randomize colors
- added a new field "color" to activeUsers
- use of style props to render custom colors (since tailwind doesn't support dynamic classnames that is generated in the server)
- added if room is matching type check in removeRoom (the bug mentioned above was caused by the first invite getting removed from the removeRoom of the second invite since it tries to remove any rooms that the user is in before joining a new invitation room; this causes the room to only have 1 player, hence getting cleaned by another function)