### PR TITLE
Feature/fix excess rooms [BIG CHANGE]

### DIFF
--- a/Client/src/components/Chat.tsx
+++ b/Client/src/components/Chat.tsx
@@ -13,7 +13,8 @@ export default function Chat() {
         chatHistory, 
         name, 
         gameInfo,
-        activeUsers
+        activeUsers,
+        flags,
     } = global_state;
     const { socket } = React.useContext(SocketContext);
     const [ chatHeight, setChatHeight ] = React.useState<number>(0);
@@ -29,16 +30,14 @@ export default function Chat() {
         return ()=>window.removeEventListener('resize',chatHeightHandler);
     },[])
     React.useEffect(()=>{
-        if (socket !== undefined) {
-            //waits for server to load activeUsers first before sending request
-            setTimeout(()=>{
-                socket.emit('chat request',{ 
-                    name:name, 
-                    roomID:gameInfo?.roomID
-                });
-            },700)
+        if (socket !== undefined && flags.activeUsersInitialized) {
+            //waits for server to emit back activeUsers to send chat request
+            socket.emit('chat request',{ 
+                name:name, 
+                roomID:gameInfo?.roomID
+            });
         }
-    },[socket])
+    },[socket,flags.activeUsersInitialized])
     return (
         <div 
             className={`flex flex-col justify-evenly font-quicksand text-xl h-full`}

--- a/Client/src/components/Chat.tsx
+++ b/Client/src/components/Chat.tsx
@@ -32,10 +32,11 @@ export default function Chat() {
     React.useEffect(()=>{
         if (socket !== undefined && flags.activeUsersInitialized) {
             //waits for server to emit back activeUsers to send chat request
-            socket.emit('chat request',{ 
+            socket.emit("chat request",{ 
                 name:name, 
                 roomID:gameInfo?.roomID
             });
+            return ()=>socket.off("chat request") as any;
         }
     },[socket,flags.activeUsersInitialized])
     return (

--- a/Client/src/components/Countdown.tsx
+++ b/Client/src/components/Countdown.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction } from 'react'
+import React from 'react'
 import { addSeconds, differenceInSeconds } from 'date-fns'
 
 interface CountdownPropsType {

--- a/Client/src/components/InviteButton.tsx
+++ b/Client/src/components/InviteButton.tsx
@@ -1,3 +1,4 @@
+import de from 'date-fns/esm/locale/de/index.js';
 import React from 'react'
 import { playAudio } from '../lib/utility/Audio';
 import { SocketContext } from '../socket'
@@ -12,35 +13,67 @@ interface InviteButtonPropsType {
 export default function InviteButton({ user }:InviteButtonPropsType) {
     const { global_state, dispatch } = React.useContext(GlobalContext);
     const { socket } = React.useContext(SocketContext);
-    const { activeUsers, name, flags, receiver } = global_state;
+    const { 
+        activeUsers, 
+        name, 
+        flags, 
+        receivedInvite,
+        pendingInvite,
+    } = global_state;
     const [ trigger, setTrigger ] = React.useState<boolean>(false);
+    //to make callback use the latest pendingInvite value
+    const pendingInviteRef = React.useRef<any>();
+    pendingInviteRef.current = pendingInvite;
+
     const handleOnClick = () => {
         socket.emit("invite request",{ senderName:name, receiverName:user.name });
         playAudio('pop.wav');
         setTrigger(true);
+        const newFlags = { ...flags, canMatch: false };
+        const newPendingInvite = { ...pendingInvite };
+        newPendingInvite[user.name] = user.name;
+        dispatch({
+            type:"multi-set",
+            field:["flags","pendingInvite"],
+            payload:[newFlags,newPendingInvite],
+        });
     };
     const checkCanInvite = () => {
         return (!activeUsers.find((activeUser:UserType)=>
             activeUser.name === user.name)?.inGame
-        ) && !flags.isMatching
+        ) && !flags.isMatching;
     };
     React.useEffect(()=>{
-        console.log(receiver)
-        if (Object.keys(receiver).length !== 0) {
-            const check = receiver[user.name]
+        console.log("RECEIVED INVITES",Object.keys(receivedInvite));
+        if (Object.keys(receivedInvite).length !== 0) {
+            const check = receivedInvite[user.name]
             console.log(check)
             if (check !== undefined) {
                 setTrigger(false);
-                const newReceiver = { ...receiver };
-                delete newReceiver[user.name];
+                const newReceivedInvite = { ...receivedInvite };
+                delete newReceivedInvite[user.name];
+                console.log("i got a reply, removing pending invite for",user.name);
+                const newPendingInvite = { ...pendingInvite };
+                delete newPendingInvite[user.name];
                 dispatch({
-                    type:"set",
-                    field:"receiver",
-                    payload:newReceiver,
+                    type:"multi-set",
+                    field:["receivedInvite","pendingInvite"],
+                    payload:[newReceivedInvite,newPendingInvite],
                 });
             }
         }
-    },[receiver])
+    },[receivedInvite]);
+    React.useEffect(()=>{
+        console.log("PENDING INVITES",Object.keys(pendingInvite));
+        if (Object.keys(pendingInvite).length === 0) {
+            const newFlags = { ...flags, canMatch: true };
+            dispatch({
+                type:"set",
+                field:"flags",
+                payload:newFlags,
+            });
+        }
+    },[pendingInvite])
     return (
         user.name !== name?
         <div className="relative">
@@ -50,7 +83,17 @@ export default function InviteButton({ user }:InviteButtonPropsType) {
                 <Countdown
                     seconds={15}
                     trigger={trigger}
-                    callback={()=>setTrigger(false)}
+                    callback={()=>{
+                        setTrigger(false)
+                        const newPendingInvite = { ...pendingInviteRef.current };
+                        console.log('expired, deleting',user.name, newPendingInvite);
+                        delete newPendingInvite[user.name];
+                        dispatch({
+                            type:"set",
+                            field:"pendingInvite",
+                            payload:newPendingInvite,
+                        });
+                    }}
                 />
             </div>
             <button

--- a/Client/src/components/MatchingButton.tsx
+++ b/Client/src/components/MatchingButton.tsx
@@ -28,7 +28,7 @@ export default function MatchingButton() {
             setTimeout(()=>setCooldown(false),1000)
         }
     }
-    return (
+    return (flags.canMatch?
         <button
             disabled={cooldown}
             onClick={handleOnClick}
@@ -46,5 +46,6 @@ export default function MatchingButton() {
                 </svg>
             }
         </button>
+        :null
     )
 }

--- a/Client/src/components/MinesGrid.tsx
+++ b/Client/src/components/MinesGrid.tsx
@@ -8,8 +8,8 @@ import FoundMineEffect from './FoundMineEffect'
 import { getUserColor } from '../lib/utility/GetUserColor'
 
 export default function MinesGrid() {
-    const { global_state } = React.useContext(GlobalContext)
-    const { gameInfo, name } = global_state
+    const { global_state } = React.useContext(GlobalContext);
+    const { gameInfo, name } = global_state;
     const checkPlayerCanInteract = () => {
         const playingUser =  gameInfo.users[gameInfo.playingUser]
         return playingUser.name === name

--- a/Client/src/components/ReplyReceiver.tsx
+++ b/Client/src/components/ReplyReceiver.tsx
@@ -6,7 +6,7 @@ import { playAudio } from '../lib/utility/Audio';
 export default function ReplyReceiver() {
     const { global_state, dispatch } = React.useContext(GlobalContext) ;
     const { socket }:any = React.useContext(SocketContext);
-    const { receiver } = global_state;
+    const { receivedInvite } = global_state;
     const [ mode, setMode ] = React.useState<number>(0);
     //mode 0 = not visible
     //mode 1 = (sender) gets accepted or decline
@@ -26,12 +26,12 @@ export default function ReplyReceiver() {
                 console.log(receiverName,decision)
                 setDecision(decision);
                 setReceiverName(receiverName);
-                const newReceiver = { ...receiver };
-                newReceiver[receiverName] = decision;
+                const newReceivedInvite = { ...receivedInvite };
+                newReceivedInvite[receiverName] = decision;
                 dispatch({
                     type:"set",
-                    field:"receiver",
-                    payload:newReceiver,
+                    field:"receivedInvite",
+                    payload:newReceivedInvite,
                 })
                 setMode(1);
                 playAudio('noti.wav');

--- a/Client/src/components/RequestReceiver.tsx
+++ b/Client/src/components/RequestReceiver.tsx
@@ -7,8 +7,8 @@ import { playAudio } from '../lib/utility/Audio';
 
 export default function RequestReceiver() {
     const { socket }:any = React.useContext(SocketContext);
-    const { global_state } = React.useContext(GlobalContext);
-    const { name } = global_state;
+    const { global_state, dispatch } = React.useContext(GlobalContext);
+    const { name, flags } = global_state;
     const [ mode, setMode ] = React.useState<number>(0);
     const [ trigger, setTrigger ] = React.useState<boolean>(false);
     //mode 0 = not visible
@@ -31,6 +31,12 @@ export default function RequestReceiver() {
         } else {
             console.log('error occured at invite onClick()');
         }
+        const newFlags = { ...flags, canMatch:true };
+        dispatch({
+            type:"set",
+            field:"flags",
+            payload:newFlags,
+        })
     }
     const handleOnClickClose = () => {
         playAudio('pop.wav');
@@ -49,6 +55,12 @@ export default function RequestReceiver() {
                 playAudio('noti.wav')
                 console.log(senderName, roomID, error);
                 if (error===undefined && senderName!==undefined && roomID!==undefined) {
+                    const newFlags = { ...flags, canMatch:false };
+                    dispatch({
+                        type:"set",
+                        field:"flags",
+                        payload:newFlags,
+                    });
                     setInviteStorage({ senderName:senderName });
                     setMode(1);
                     setTrigger(true);
@@ -86,6 +98,12 @@ export default function RequestReceiver() {
                                 trigger={trigger}
                                 callback={()=>{
                                     setTrigger(false);
+                                    const newFlags = { ...flags, canMatch:true };
+                                    dispatch({
+                                        type:"set",
+                                        field:"flags",
+                                        payload:newFlags,
+                                    });
                                     setMode(0);
                                 }}
                             />

--- a/Client/src/pages/Name.tsx
+++ b/Client/src/pages/Name.tsx
@@ -1,10 +1,12 @@
 import React, { FormEvent } from 'react'
-import { GlobalContext } from '../states';
+import { GlobalContext, initialState } from '../states';
 import { useNavigate } from 'react-router-dom';
+import { SocketContext } from '../socket';
 
 export default function Name() {
-    const { dispatch } = React.useContext(GlobalContext)
-    const navigate = useNavigate()
+    const { socket } = React.useContext(SocketContext);
+    const { dispatch } = React.useContext(GlobalContext);
+    const navigate = useNavigate();
     const nameRef = React.useRef<HTMLInputElement>(null);
     const handleOnSubmit = (e:FormEvent) => {
         e.preventDefault()
@@ -13,11 +15,21 @@ export default function Name() {
                 type:'set',
                 field:'name',
                 payload:nameRef.current.value
-            })
-            nameRef.current.value = ""
-            navigate('menu')
+            });
+            nameRef.current.value = "";
+            navigate('menu');
         }
     }
+    React.useEffect(()=>{
+        sessionStorage.setItem("fmm-state", JSON.stringify(initialState));
+        dispatch({
+            type:"set",
+            payload:initialState,
+        });
+        if (socket !== undefined) {
+            socket.disconnect();
+        }
+    },[socket])
     return (
         <div className="flex bg-gradient-to-t from-transparent to-slate-700 w-full h-screen p-5">
             <div className="absolute top-0 botom-0 left-0 right-0 -z-10 bg-cover blur-sm

--- a/Client/src/socket.tsx
+++ b/Client/src/socket.tsx
@@ -15,7 +15,10 @@ export const SocketContext = createContext<SocketContextType>(
 );
 
 export const SocketProvider = ({ children }: { children: React.ReactNode }) => {
-	const { global_state, dispatch } = React.useContext(GlobalContext);
+	const { 
+		global_state, 
+		dispatch,
+	} = React.useContext(GlobalContext);
 	const { gameInfo, name, flags } = global_state;
 	const [socket, setSocket] = React.useState<Socket | undefined>(undefined);
 	const [reconnectInGame, setReconnectInGame] = React.useState<boolean>(false);
@@ -44,14 +47,19 @@ export const SocketProvider = ({ children }: { children: React.ReactNode }) => {
 			});
 			socket.on("active user update", (activeUsers: any) => {
 				const users:Array<UserType> = Object.values(activeUsers)
+				const newFlags = { ...flags, activeUsersInitialized:true };
 				dispatch({
-					type:"set",
-					field:"activeUsers",
-					payload:users
+					type:"multi-set",
+					field:["activeUsers","flags"],
+					payload:[users, newFlags],
 				})
 			});
 			socket.on("start game", (gameInfo: GameInfoType) => {
-				const newFlags = { ...flags, resultVisible: false };
+				const newFlags = { 
+					...flags, 
+					resultVisible: false,
+					isMatching: false,
+			 };
 				dispatch({
 					type: "multi-set",
 					field: ["gameInfo", "flags"],

--- a/Client/src/states.tsx
+++ b/Client/src/states.tsx
@@ -15,11 +15,13 @@ export const initialState: GlobalStateType = {
 	name: "",
 	chatHistory: [],
 	activeUsers: [],
-	receiver: {},
+	pendingInvite: {},
+	receivedInvite: {},
 	gameInfo: {} as GameInfoType,
 	socketID: "",
 	flags: {
 		activeUsersInitialized: false,
+		canMatch: true,
 		resultVisible: false,
 		userLeft: false,
 		isMatching: false,
@@ -60,7 +62,9 @@ export function GlobalStateProvider({
 					newState[action.field as string] = action.payload;
 					save(newState);
 					return newState;
-				} else return state;
+				} else {
+					return action.payload;
+				};
 			case "multi-set":
 				if (action.field !== undefined) {
 					for (let i = 0; i < action.field.length; i++) {
@@ -78,7 +82,6 @@ export function GlobalStateProvider({
 		}
 	};
 	const [ state, dispatch ] = React.useReducer(reducer, getSessionData());
-	//state that do not want to be saved in session storage
 	return (
 		<GlobalContext.Provider value={{ 
 			global_state: state, 

--- a/Client/src/states.tsx
+++ b/Client/src/states.tsx
@@ -19,6 +19,7 @@ export const initialState: GlobalStateType = {
 	gameInfo: {} as GameInfoType,
 	socketID: "",
 	flags: {
+		activeUsersInitialized: false,
 		resultVisible: false,
 		userLeft: false,
 		isMatching: false,
@@ -41,7 +42,9 @@ const save = (state: GlobalStateType) => {
 };
 
 const load = () => {
-	return JSON.parse(sessionStorage.getItem("fmm-state") as string);
+	const res = JSON.parse(sessionStorage.getItem("fmm-state") as string);
+	//reset flags
+	return { ...res, flags:initialState.flags }
 };
 
 export function GlobalStateProvider({
@@ -74,9 +77,13 @@ export function GlobalStateProvider({
 				return state;
 		}
 	};
-	const [state, dispatch] = React.useReducer(reducer, getSessionData());
+	const [ state, dispatch ] = React.useReducer(reducer, getSessionData());
+	//state that do not want to be saved in session storage
 	return (
-		<GlobalContext.Provider value={{ global_state: state, dispatch: dispatch }}>
+		<GlobalContext.Provider value={{ 
+			global_state: state, 
+			dispatch: dispatch,
+		}}>
 			{children}
 		</GlobalContext.Provider>
 	);

--- a/Client/src/types.ts
+++ b/Client/src/types.ts
@@ -40,6 +40,7 @@ export interface GameInfoType {
 	minesArray: Array<BlockType>;
 }
 export interface FlagsType {
+	activeUsersInitialized: boolean;
 	userLeft: boolean;
 	resultVisible: boolean;
 	isMatching: boolean;

--- a/Client/src/types.ts
+++ b/Client/src/types.ts
@@ -41,6 +41,7 @@ export interface GameInfoType {
 }
 export interface FlagsType {
 	activeUsersInitialized: boolean;
+	canMatch: boolean;
 	userLeft: boolean;
 	resultVisible: boolean;
 	isMatching: boolean;
@@ -62,7 +63,8 @@ export interface GlobalStateType extends GlobalStateKeys {
     name:string;
     chatHistory:Array<MessageType>;
     activeUsers:Array<UserType>;
-	receiver: any;
+	pendingInvite: any;
+	receivedInvite: any;
     gameInfo:GameInfoType;
     socketID:string;
     flags:FlagsType;


### PR DESCRIPTION
Main changes:
- fixed excess rooms generated
- fixed rooms getting removed unintentionally
- cannot match and invite simultaneously (most of the time unless you try really hard)
- server refactored
- less crashes during development

Details:

[ SERVER ]
- removed room tearing after invitation was declined (if 2 invites were sent, first receiver decline and second receiver won't be able to start the game since the sender has already left and gets removed by room cleaning function)
- info.users array are now for history tracking purposes and handing user data to the client, whereas sockets.length from fetchSockets() will now be mainly used for checking how many users are connected to the room
- introduced state field in gameInfo (purpose is to give room cleaning functions more information about the state of the room, whether the room should be removed or not)
   1. state = 0, game is inactive and no one is currently connected and should be removed
   2. state = 1, (default when generated) game is active but the timer hasn't started (1 person is connected)
   3. state = 2, game is active and the timer has already started (2 player connected is required to start)
- removed cleanGameInfo functions leaving only 1 left located inside "leave-room" event, thus the current room cleaning functions can be divided into 2 main parts:
  1. (invitation part) removes when invitation has expired and socket connected is less than 2 and game was never started
  2. (general part) fires when a player leaves a game room and if the game had already started, removes when the number of sockets connected to the room is 0 or if the player 1 score + player 2 score = winning score
 - sockets now have names attached (after "name register" is completed) (for ease of access to names)
 - some undefined guarding to reduce number of crashes during development

[CLIENT]
- name page automatically disconnects socket if connected, resets the state and session storage
- new flag added "activeUsersInitialized" is triggered after the first "active user update" event right after "name register" (purpose is to let the client know that the server has an active users list for the chat to send a request)
- chat now uses "activeUsersInitialized" before sending request
- session storage now doesn't save flags
- added listener in useEffect for active users component (purpose is to keep active users more updated)
- added useEffect cleaners for both active users component and chat component
- another flag added "canMatch" (purpose is to control if matching can be done or not) (removes matching button if active)
- added a new field "pendingInvite" in global state and renamed "receiver" -> "receivedInvite" (purpose is for invite button components to be able to detect if each pending invite has expired or realized in order to set "canMatch" flag)
- "start game" event now resets some flags in some cases where flags weren't reverted back (ex: when you are matching and game started)
- "other user left" event now has a fail-safe dispatch in case where first dispatch fails


