### PR TITLE
Feature/mines limit part2

### DIFF
--- a/Client/src/components/FoundMineEffect.tsx
+++ b/Client/src/components/FoundMineEffect.tsx
@@ -22,28 +22,28 @@ export default function FoundMineEffect({
 			case "Legendary":
 				setEffects({
 					gifSize: "scale-[400%] left-4 top-3",
-					text: "text-3xl text-yellow-500 -right-48",
+					text: "text-3xl text-yellow-500 drop-shadow-[2px_2px_2px_rgba(0,0,0,1)] -right-48",
 					points: defaultMinesConfig["Legendary"].points,
 				});
 				break;
 			case "Epic":
 				setEffects({
 					gifSize: "scale-[300%] left-4 top-3",
-					text: "text-2xl text-red-500 -right-28",
+					text: "text-2xl text-red-500 drop-shadow-[2px_2px_0px_rgba(0,0,0,1)] -right-28",
 					points: defaultMinesConfig["Epic"].points,
 				});
 				break;
 			case "Rare":
 				setEffects({
 					gifSize: "scale-[200%] left-3 top-1",
-					text: "text-xl text-cyan-400 -right-24",
+					text: "text-xl text-cyan-400 drop-shadow-[2px_2px_0px_rgba(0,0,0,1)] -right-24",
 					points: defaultMinesConfig["Rare"].points,
 				});
 				break;
 			case "Common":
 				setEffects({
 					gifSize: "scale-[100%] left-1 top-1",
-					text: "text-lg text-neutral-400 -right-20",
+					text: "text-lg text-neutral-400 drop-shadow-[2px_2px_0px_rgba(0,0,0,1)] -right-20",
 					points: defaultMinesConfig["Common"].points,
 				});
 				break;
@@ -54,13 +54,13 @@ export default function FoundMineEffect({
 	React.useEffect(() => {
 		if (trigger) {
 			setVisible(true);
-			setTimeout(() => setVisible(false), 1500);
+			setTimeout(() => setVisible(false), 1000);
 		}
 	}, [trigger]);
 	React.useEffect(() => {
 		if (visible) {
 			setTimeout(() => setTransition(true), 100);
-			setTimeout(() => setTransition(false), 1400);
+			setTimeout(() => setTransition(false), 700);
 		}
 	}, [visible]);
 	return visible && minesType !== null ? (
@@ -72,11 +72,11 @@ export default function FoundMineEffect({
 				alt=""
 			/>
 			<div
-				className={`absolute transition duration-[1000ms] brightness-150 z-20 drop-shadow-sm
+				className={`absolute transition duration-[700ms] brightness-150 z-20
                 ${
 									transition
 										? "-translate-y-20 opacity-100 scale-100"
-										: "translate-y-0 opacity-0 scale-50"
+										: "translate-y-0 opacity-0 scale-60"
 								} 
                 font-righteous ${effects.text}`}
 			>

--- a/Client/src/components/GridSizeButton.tsx
+++ b/Client/src/components/GridSizeButton.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+
+interface GridSizeButtonPropsType {
+	stateChangeCallback: Function;
+	min: number;
+	max: number;
+	initial: number;
+}
+
+export default function GridSizeButton({
+	stateChangeCallback,
+	min,
+	max,
+	initial,
+}: GridSizeButtonPropsType) {
+	const [number, setNumber] = React.useState<number>(initial);
+	const minMaxCheck = (num: number) => {
+		return num >= min && num <= max;
+	};
+	const handleOnClick = (isIncrement: boolean) => {
+		if (isIncrement) {
+			if (minMaxCheck(number + 1)) setNumber(number + 1);
+			else setNumber(max);
+		} else {
+			if (minMaxCheck(number - 1)) setNumber(number - 1);
+			else setNumber(min);
+		}
+	};
+	React.useEffect(() => {
+		stateChangeCallback(number);
+	}, [number]);
+	return (
+		<div className="flex rounded-full bg-opacity-50 bg-neutral-700 w-full p-0.5 my-0.5">
+			<button
+				onClick={() => handleOnClick(false)}
+				className="hover:scale-125 transition"
+			>
+				<svg
+					className="w-5 h-5 hover:fill-white fill-neutral-500"
+					xmlns="http://www.w3.org/2000/svg"
+					viewBox="0 0 384 512"
+				>
+					<path d="M41.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l192 192c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.3 256 278.6 86.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-192 192z" />
+				</svg>
+			</button>
+			<div className="flex w-full">
+				<div className="m-auto">
+					{number} x {number}
+				</div>
+			</div>
+
+			<button
+				onClick={() => handleOnClick(true)}
+				className="hover:scale-125 transition"
+			>
+				<svg
+					className="w-5 h-5 hover:fill-white fill-neutral-500"
+					xmlns="http://www.w3.org/2000/svg"
+					viewBox="0 0 384 512"
+				>
+					<path d="M342.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L274.7 256 105.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z" />
+				</svg>
+			</button>
+		</div>
+	);
+}

--- a/Client/src/components/GridSizeButton.tsx
+++ b/Client/src/components/GridSizeButton.tsx
@@ -30,10 +30,10 @@ export default function GridSizeButton({
 		stateChangeCallback(number);
 	}, [number]);
 	return (
-		<div className="flex rounded-full bg-opacity-50 bg-neutral-700 w-full p-0.5 my-0.5">
+		<div className="relative flex rounded-full bg-opacity-50 bg-neutral-700 w-full p-0.5 my-0.5">
 			<button
 				onClick={() => handleOnClick(false)}
-				className="hover:scale-125 transition"
+				className="hover:scale-125 transition absolute -left-5 top-0 bottom-0"
 			>
 				<svg
 					className="w-5 h-5 hover:fill-white fill-neutral-500"
@@ -51,7 +51,7 @@ export default function GridSizeButton({
 
 			<button
 				onClick={() => handleOnClick(true)}
-				className="hover:scale-125 transition"
+				className="hover:scale-125 transition absolute -right-5 top-0 bottom-0"
 			>
 				<svg
 					className="w-5 h-5 hover:fill-white fill-neutral-500"

--- a/Client/src/components/IncrementDecrementButton.tsx
+++ b/Client/src/components/IncrementDecrementButton.tsx
@@ -25,7 +25,6 @@ export default function IncrementDecrementButton({
 }: IncrementDecrementButtonPropsType) {
 	const [number, setNumber] = React.useState<number>(initial);
 	const minMaxCheck = (num: number) => {
-		console.log(num, min, num >= min);
 		return num >= min && num <= max;
 	};
 	const handleOnClick = (isIncrement: boolean) => {

--- a/Client/src/components/IncrementDecrementButton.tsx
+++ b/Client/src/components/IncrementDecrementButton.tsx
@@ -4,7 +4,7 @@ interface IncrementDecrementButtonPropsType {
 	stateChangeCallback: Function;
 	min: number;
 	max: number;
-	maxDisabled: boolean;
+	maxDisabled?: boolean;
 	initial: number;
 	className?: string;
 	buttonClassName?: string;

--- a/Client/src/components/IncrementDecrementButton.tsx
+++ b/Client/src/components/IncrementDecrementButton.tsx
@@ -4,6 +4,7 @@ interface IncrementDecrementButtonPropsType {
 	stateChangeCallback: Function;
 	min: number;
 	max: number;
+	maxDisabled: boolean;
 	initial: number;
 	className?: string;
 	buttonClassName?: string;
@@ -15,6 +16,7 @@ export default function IncrementDecrementButton({
 	stateChangeCallback,
 	min,
 	max,
+	maxDisabled,
 	initial,
 	className,
 	buttonClassName,
@@ -40,7 +42,13 @@ export default function IncrementDecrementButton({
 	}, [number]);
 	return (
 		<div className={className}>
-			<button onClick={() => handleOnClick(true)} className={buttonClassName}>
+			<button
+				disabled={maxDisabled}
+				onClick={() => handleOnClick(true)}
+				className={`${buttonClassName} ${
+					maxDisabled ? "opacity-0" : "opacity-100"
+				}`}
+			>
 				<svg
 					className={svgClassName}
 					xmlns="http://www.w3.org/2000/svg"

--- a/Client/src/components/IncrementDecrementButton.tsx
+++ b/Client/src/components/IncrementDecrementButton.tsx
@@ -41,6 +41,16 @@ export default function IncrementDecrementButton({
 	}, [number]);
 	return (
 		<div className={className}>
+			<button onClick={() => handleOnClick(false)} className={buttonClassName}>
+				<svg
+					className={svgClassName}
+					xmlns="http://www.w3.org/2000/svg"
+					viewBox="0 0 448 512"
+				>
+					<path d="M432 256c0 17.7-14.3 32-32 32L48 288c-17.7 0-32-14.3-32-32s14.3-32 32-32l352 0c17.7 0 32 14.3 32 32z" />
+				</svg>
+			</button>
+			<div className={textClassName}>{number}</div>
 			<button
 				disabled={maxDisabled}
 				onClick={() => handleOnClick(true)}
@@ -54,16 +64,6 @@ export default function IncrementDecrementButton({
 					viewBox="0 0 448 512"
 				>
 					<path d="M256 80c0-17.7-14.3-32-32-32s-32 14.3-32 32V224H48c-17.7 0-32 14.3-32 32s14.3 32 32 32H192V432c0 17.7 14.3 32 32 32s32-14.3 32-32V288H400c17.7 0 32-14.3 32-32s-14.3-32-32-32H256V80z" />
-				</svg>
-			</button>
-			<div className={textClassName}>{number}</div>
-			<button onClick={() => handleOnClick(false)} className={buttonClassName}>
-				<svg
-					className={svgClassName}
-					xmlns="http://www.w3.org/2000/svg"
-					viewBox="0 0 448 512"
-				>
-					<path d="M432 256c0 17.7-14.3 32-32 32L48 288c-17.7 0-32-14.3-32-32s14.3-32 32-32l352 0c17.7 0 32 14.3 32 32z" />
 				</svg>
 			</button>
 		</div>

--- a/Client/src/components/PreInviteOptions.tsx
+++ b/Client/src/components/PreInviteOptions.tsx
@@ -8,6 +8,7 @@ import {
 } from "../lib/defaults/Default";
 import IncrementDecrementButton from "./IncrementDecrementButton";
 import Image from "./Image";
+import GridSizeButton from "./GridSizeButton";
 interface PreInviteOptionsPropsType {
 	setInviteOptions: Dispatch<SetStateAction<InviteMessageType>>;
 	visible: boolean;
@@ -110,21 +111,20 @@ export default function PreInviteOptions({
 					INVITE OPTIONS
 				</div>
 				<div className="flex justify-evenly">
-					<div />
-					<div>
-						Grid size:
-						<input
-							onChange={handleOnChange}
-							ref={gridSizeRef}
-							className="rounded-full text-center text-lg bg-neutral-700 bg-opacity-50 mx-2"
-							type="number"
-							defaultValue={defaultGridSizeInput}
-							max={10}
+					<div className="w-[15%]" />
+					<div className="w-[15%]">
+						<div className="text-white">Grid size:</div>
+						<GridSizeButton
+							stateChangeCallback={(num: number) => {
+								setGridSizeInput(num);
+							}}
+							initial={defaultGridSizeInput}
 							min={2}
+							max={10}
 						/>
 					</div>
-					<div>
-						Total Mines:
+					<div className="w-[15%]">
+						<div className="text-white">Total mines:</div>
 						<div className="flex rounded-full bg-opacity-50 bg-neutral-700 w-full p-0.5 my-0.5">
 							<div className="m-auto">{getTotalMines()}</div>
 						</div>

--- a/Client/src/components/PreInviteOptions.tsx
+++ b/Client/src/components/PreInviteOptions.tsx
@@ -2,7 +2,10 @@ import React, { Dispatch, SetStateAction } from "react";
 import { InviteMessageType, MinesConfigType, MinesLeftType } from "../types";
 import { playAudio } from "../lib/utility/Audio";
 import filter from "bad-words";
-import { defaultGridSize, defaultMinesConfig } from "../lib/defaults/Default";
+import {
+	defaultGridSizeInput,
+	defaultMinesConfig,
+} from "../lib/defaults/Default";
 import IncrementDecrementButton from "./IncrementDecrementButton";
 import Image from "./Image";
 interface PreInviteOptionsPropsType {
@@ -27,6 +30,8 @@ export default function PreInviteOptions({
 		getMinesAmountArray(defaultMinesConfig)
 	);
 	//maxLimit = 0 under limit, maxLimit = 1 at limit, maxLimit = 2 exceeded limit
+	const [gridSizeInput, setGridSizeInput] =
+		React.useState<number>(defaultGridSizeInput);
 	const [maxLimit, setMaxLimit] = React.useState<number>(0);
 	const gridSizeRef = React.useRef<HTMLInputElement>(null);
 	const textAreaRef = React.useRef<HTMLTextAreaElement>(null);
@@ -51,7 +56,7 @@ export default function PreInviteOptions({
 				ready: true,
 			});
 			textAreaRef.current.value = "";
-			gridSizeRef.current.value = defaultGridSize.toString();
+			gridSizeRef.current.value = defaultGridSizeInput.toString();
 			handleOnClose();
 		}
 	};
@@ -113,7 +118,7 @@ export default function PreInviteOptions({
 							ref={gridSizeRef}
 							className="rounded-full text-center text-lg bg-neutral-700 bg-opacity-50 mx-2"
 							type="number"
-							defaultValue={defaultGridSize}
+							defaultValue={defaultGridSizeInput}
 							max={10}
 							min={2}
 						/>

--- a/Client/src/components/PreInviteOptions.tsx
+++ b/Client/src/components/PreInviteOptions.tsx
@@ -26,7 +26,7 @@ export default function PreInviteOptions({
 	const [minesAmount, setMinesAmount] = React.useState<MinesLeftType>(
 		getMinesAmountArray(defaultMinesConfig)
 	);
-	const [maxLimit, setMaxLimit] = React.useState<boolean>(false); 
+	const [maxLimit, setMaxLimit] = React.useState<boolean>(false);
 	const gridSizeRef = React.useRef<HTMLInputElement>(null);
 	const textAreaRef = React.useRef<HTMLTextAreaElement>(null);
 	const handleOnClose = () => {
@@ -54,25 +54,35 @@ export default function PreInviteOptions({
 			handleOnClose();
 		}
 	};
-	const minesLimit = (gridSize:number,minesAmount:MinesLeftType) => {
-		let maxcount = minesAmount.Legendary+minesAmount.Epic+minesAmount.Rare+minesAmount.Common;
+	const minesLimit = (gridSize: number, minesAmount: MinesLeftType) => {
+		let maxcount =
+			minesAmount.Legendary +
+			minesAmount.Epic +
+			minesAmount.Rare +
+			minesAmount.Common;
 		console.log(maxcount);
-		if (maxcount>=gridSize) {
+		if (maxcount >= gridSize) {
 			setMaxLimit(true);
-		}else setMaxLimit(false);
+		} else setMaxLimit(false);
 	};
 	const handleOnChange = () => {
 		console.log(maxLimit);
 		if (gridSizeRef.current !== null) {
-			minesLimit(Number(gridSizeRef.current.value)*Number(gridSizeRef.current.value),minesAmount);
+			minesLimit(
+				Number(gridSizeRef.current.value) * Number(gridSizeRef.current.value),
+				minesAmount
+			);
 		}
-	}
-	React.useEffect(()=>{
+	};
+	React.useEffect(() => {
 		console.log(maxLimit);
 		if (gridSizeRef.current !== null) {
-			minesLimit(Number(gridSizeRef.current.value)*Number(gridSizeRef.current.value),minesAmount);
+			minesLimit(
+				Number(gridSizeRef.current.value) * Number(gridSizeRef.current.value),
+				minesAmount
+			);
 		}
-	},[minesAmount]);
+	}, [minesAmount]);
 
 	return visible ? (
 		<div
@@ -119,9 +129,10 @@ export default function PreInviteOptions({
 									initial={minesAmount[key]}
 									min={0}
 									max={100}
+									maxDisabled={maxLimit}
 									className="flex rounded-full bg-opacity-50 bg-neutral-700 w-fit p-0.5 my-0.5"
-									buttonClassName="w-7 h-7 rounded-full bg-neutral-300 opacity-20 hover:scale-110 
-									transition duration-200 hover:opacity-80 m-auto"
+									buttonClassName="w-7 h-7 rounded-full bg-neutral-300 hover:scale-110 
+									transition duration-200 hover:bg-opacity-80 m-auto bg-opacity-20"
 									textClassName="m-auto px-5"
 									svgClassName="w-6 h-6 m-auto"
 								/>

--- a/Client/src/components/PreInviteOptions.tsx
+++ b/Client/src/components/PreInviteOptions.tsx
@@ -55,13 +55,16 @@ export default function PreInviteOptions({
 			handleOnClose();
 		}
 	};
-	const minesLimit = (gridSize: number, minesAmount: MinesLeftType) => {
-		let maxcount =
+	const getTotalMines = () => {
+		return (
 			minesAmount.Legendary +
 			minesAmount.Epic +
 			minesAmount.Rare +
-			minesAmount.Common;
-		console.log(maxcount);
+			minesAmount.Common
+		);
+	};
+	const minesLimit = (gridSize: number) => {
+		let maxcount = getTotalMines();
 		if (maxcount === gridSize) {
 			setMaxLimit(1);
 		} else if (maxcount > gridSize) {
@@ -72,8 +75,7 @@ export default function PreInviteOptions({
 		console.log(maxLimit);
 		if (gridSizeRef.current !== null) {
 			minesLimit(
-				Number(gridSizeRef.current.value) * Number(gridSizeRef.current.value),
-				minesAmount
+				Number(gridSizeRef.current.value) * Number(gridSizeRef.current.value)
 			);
 		}
 	};
@@ -81,8 +83,7 @@ export default function PreInviteOptions({
 		console.log(maxLimit);
 		if (gridSizeRef.current !== null) {
 			minesLimit(
-				Number(gridSizeRef.current.value) * Number(gridSizeRef.current.value),
-				minesAmount
+				Number(gridSizeRef.current.value) * Number(gridSizeRef.current.value)
 			);
 		}
 	}, [minesAmount]);
@@ -103,17 +104,26 @@ export default function PreInviteOptions({
 				<div className="text-cyan-400 text-3xl font-righteous mb-2">
 					INVITE OPTIONS
 				</div>
-				<div>
-					Grid size:
-					<input
-						onChange={handleOnChange}
-						ref={gridSizeRef}
-						className="rounded-full text-center text-lg bg-neutral-700 bg-opacity-50 mx-2"
-						type="number"
-						defaultValue={defaultGridSize}
-						max={10}
-						min={2}
-					/>
+				<div className="flex justify-evenly">
+					<div />
+					<div>
+						Grid size:
+						<input
+							onChange={handleOnChange}
+							ref={gridSizeRef}
+							className="rounded-full text-center text-lg bg-neutral-700 bg-opacity-50 mx-2"
+							type="number"
+							defaultValue={defaultGridSize}
+							max={10}
+							min={2}
+						/>
+					</div>
+					<div>
+						Total Mines:
+						<div className="flex rounded-full bg-opacity-50 bg-neutral-700 w-full p-0.5 my-0.5">
+							<div className="m-auto">{getTotalMines()}</div>
+						</div>
+					</div>
 				</div>
 				<div className="p-3">
 					{Object.keys(minesAmount).map((key) => {
@@ -153,7 +163,7 @@ export default function PreInviteOptions({
 					disabled={Boolean(maxLimit)}
 					className={`basis-[10%] bg-green-600 p-2 rounded-full duration-300
                     hover:scale-[102%] hover:opacity-80 transition text-white text-xl text-center
-					${maxLimit ? "bg-neutral-400" : null}`}
+					${maxLimit ? "bg-neutral-700" : null}`}
 					onClick={handleOnClick}
 				>
 					Send Invite

--- a/Client/src/components/PreInviteOptions.tsx
+++ b/Client/src/components/PreInviteOptions.tsx
@@ -41,22 +41,25 @@ export default function PreInviteOptions({
 		setMinesAmount(getMinesAmountArray(defaultMinesConfig));
 	};
 	const handleOnClick = () => {
-		if (textAreaRef.current !== null) {
-			const modifiedMinesConfig = { ...defaultMinesConfig };
-			Object.keys(minesAmount).forEach((key) => {
-				modifiedMinesConfig[key].amount = minesAmount[key];
-			});
-			setInviteOptions({
-				message: new filter().clean(textAreaRef.current.value),
-				gameOptions: {
-					gridSize: gridSizeInput * gridSizeInput,
-					minesConfig: modifiedMinesConfig,
-				},
-				ready: true,
-			});
-			textAreaRef.current.value = "";
-			handleOnClose();
-		}
+		console.log(textAreaRef.current?.value);
+		let msg =
+			textAreaRef.current !== null && textAreaRef.current.value.length > 0
+				? new filter().clean(textAreaRef.current.value)
+				: "";
+		const modifiedMinesConfig = { ...defaultMinesConfig };
+		Object.keys(minesAmount).forEach((key) => {
+			modifiedMinesConfig[key].amount = minesAmount[key];
+		});
+		if (textAreaRef.current) textAreaRef.current.value = "";
+		setInviteOptions({
+			message: msg,
+			gameOptions: {
+				gridSize: gridSizeInput * gridSizeInput,
+				minesConfig: modifiedMinesConfig,
+			},
+			ready: true,
+		});
+		handleOnClose();
 	};
 	const getTotalMines = () => {
 		return (

--- a/Client/src/components/PreInviteOptions.tsx
+++ b/Client/src/components/PreInviteOptions.tsx
@@ -75,7 +75,6 @@ export default function PreInviteOptions({
 		} else setMaxLimit(0);
 	};
 	React.useEffect(() => {
-		console.log(maxLimit);
 		minesLimit(gridSizeInput * gridSizeInput);
 	}, [minesAmount, gridSizeInput]);
 
@@ -108,10 +107,31 @@ export default function PreInviteOptions({
 							max={10}
 						/>
 					</div>
-					<div className="">
+					<div className="relative">
+						<div
+							className={`absolute -top-7 left-0 right-0 ${
+								maxLimit === 1
+									? "text-yellow-300"
+									: maxLimit === 2
+									? "text-red-400"
+									: null
+							}`}
+						>
+							{maxLimit === 1 ? "MAX" : maxLimit === 2 ? "EXCEEDED" : null}
+						</div>
 						<div className="text-white">Total mines:</div>
 						<div className="flex rounded-full bg-opacity-50 bg-neutral-700 w-full p-0.5 my-0.5">
-							<div className="m-auto">{getTotalMines()}</div>
+							<div
+								className={`m-auto ${
+									maxLimit === 1
+										? "text-yellow-300"
+										: maxLimit === 2
+										? "text-red-400"
+										: null
+								}`}
+							>
+								{getTotalMines()}
+							</div>
 						</div>
 					</div>
 				</div>
@@ -151,9 +171,9 @@ export default function PreInviteOptions({
 				></textarea>
 				<button
 					disabled={Boolean(maxLimit)}
-					className={`basis-[10%] bg-green-600 p-2 rounded-full duration-300
-                    hover:scale-[102%] hover:opacity-80 transition text-white text-xl text-center
-					${maxLimit ? "bg-neutral-700" : null}`}
+					className={`basis-[10%] bg-green-600 p-2 rounded-full duration-300 shadow-lg
+                    hover:scale-[102%] hover:shadow-green-400 transition text-white text-xl text-center
+					${maxLimit ? "bg-neutral-700 opacity-50 hover:shadow-black" : null}`}
 					onClick={handleOnClick}
 				>
 					Send Invite

--- a/Client/src/components/PreInviteOptions.tsx
+++ b/Client/src/components/PreInviteOptions.tsx
@@ -34,7 +34,6 @@ export default function PreInviteOptions({
 	const [gridSizeInput, setGridSizeInput] =
 		React.useState<number>(defaultGridSizeInput);
 	const [maxLimit, setMaxLimit] = React.useState<number>(0);
-	const gridSizeRef = React.useRef<HTMLInputElement>(null);
 	const textAreaRef = React.useRef<HTMLTextAreaElement>(null);
 	const handleOnClose = () => {
 		playAudio("pop.wav");
@@ -42,8 +41,7 @@ export default function PreInviteOptions({
 		setMinesAmount(getMinesAmountArray(defaultMinesConfig));
 	};
 	const handleOnClick = () => {
-		if (textAreaRef.current !== null && gridSizeRef.current !== null) {
-			const size = Number(gridSizeRef.current.value);
+		if (textAreaRef.current !== null) {
 			const modifiedMinesConfig = { ...defaultMinesConfig };
 			Object.keys(minesAmount).forEach((key) => {
 				modifiedMinesConfig[key].amount = minesAmount[key];
@@ -51,13 +49,12 @@ export default function PreInviteOptions({
 			setInviteOptions({
 				message: new filter().clean(textAreaRef.current.value),
 				gameOptions: {
-					gridSize: size * size,
+					gridSize: gridSizeInput * gridSizeInput,
 					minesConfig: modifiedMinesConfig,
 				},
 				ready: true,
 			});
 			textAreaRef.current.value = "";
-			gridSizeRef.current.value = defaultGridSizeInput.toString();
 			handleOnClose();
 		}
 	};
@@ -77,22 +74,10 @@ export default function PreInviteOptions({
 			setMaxLimit(2);
 		} else setMaxLimit(0);
 	};
-	const handleOnChange = () => {
-		console.log(maxLimit);
-		if (gridSizeRef.current !== null) {
-			minesLimit(
-				Number(gridSizeRef.current.value) * Number(gridSizeRef.current.value)
-			);
-		}
-	};
 	React.useEffect(() => {
 		console.log(maxLimit);
-		if (gridSizeRef.current !== null) {
-			minesLimit(
-				Number(gridSizeRef.current.value) * Number(gridSizeRef.current.value)
-			);
-		}
-	}, [minesAmount]);
+		minesLimit(gridSizeInput * gridSizeInput);
+	}, [minesAmount, gridSizeInput]);
 
 	return visible ? (
 		<div
@@ -110,9 +95,9 @@ export default function PreInviteOptions({
 				<div className="text-cyan-400 text-3xl font-righteous mb-2">
 					INVITE OPTIONS
 				</div>
-				<div className="flex justify-evenly">
-					<div className="w-[15%]" />
-					<div className="w-[15%]">
+				<div className="grid grid-cols-3 grid-flow-row justify-items-center">
+					<div className="" />
+					<div className="">
 						<div className="text-white">Grid size:</div>
 						<GridSizeButton
 							stateChangeCallback={(num: number) => {
@@ -123,7 +108,7 @@ export default function PreInviteOptions({
 							max={10}
 						/>
 					</div>
-					<div className="w-[15%]">
+					<div className="">
 						<div className="text-white">Total mines:</div>
 						<div className="flex rounded-full bg-opacity-50 bg-neutral-700 w-full p-0.5 my-0.5">
 							<div className="m-auto">{getTotalMines()}</div>

--- a/Client/src/components/PreInviteOptions.tsx
+++ b/Client/src/components/PreInviteOptions.tsx
@@ -170,10 +170,10 @@ export default function PreInviteOptions({
                     rounded-3xl p-5 resize-none mb-3 text-center"
 				></textarea>
 				<button
-					disabled={Boolean(maxLimit)}
+					disabled={maxLimit === 2}
 					className={`basis-[10%] bg-green-600 p-2 rounded-full duration-300 shadow-lg
                     hover:scale-[102%] hover:shadow-green-400 transition text-white text-xl text-center
-					${maxLimit ? "bg-neutral-700 opacity-50 hover:shadow-black" : null}`}
+					${maxLimit === 2 ? "bg-neutral-700 opacity-50 hover:shadow-black" : null}`}
 					onClick={handleOnClick}
 				>
 					Send Invite

--- a/Client/src/components/PreInviteOptions.tsx
+++ b/Client/src/components/PreInviteOptions.tsx
@@ -26,7 +26,8 @@ export default function PreInviteOptions({
 	const [minesAmount, setMinesAmount] = React.useState<MinesLeftType>(
 		getMinesAmountArray(defaultMinesConfig)
 	);
-	const [maxLimit, setMaxLimit] = React.useState<boolean>(false);
+	//maxLimit = 0 under limit, maxLimit = 1 at limit, maxLimit = 2 exceeded limit
+	const [maxLimit, setMaxLimit] = React.useState<number>(0);
 	const gridSizeRef = React.useRef<HTMLInputElement>(null);
 	const textAreaRef = React.useRef<HTMLTextAreaElement>(null);
 	const handleOnClose = () => {
@@ -61,9 +62,11 @@ export default function PreInviteOptions({
 			minesAmount.Rare +
 			minesAmount.Common;
 		console.log(maxcount);
-		if (maxcount >= gridSize) {
-			setMaxLimit(true);
-		} else setMaxLimit(false);
+		if (maxcount === gridSize) {
+			setMaxLimit(1);
+		} else if (maxcount > gridSize) {
+			setMaxLimit(2);
+		} else setMaxLimit(0);
 	};
 	const handleOnChange = () => {
 		console.log(maxLimit);
@@ -129,7 +132,7 @@ export default function PreInviteOptions({
 									initial={minesAmount[key]}
 									min={0}
 									max={100}
-									maxDisabled={maxLimit}
+									maxDisabled={Boolean(maxLimit)}
 									className="flex rounded-full bg-opacity-50 bg-neutral-700 w-fit p-0.5 my-0.5"
 									buttonClassName="w-7 h-7 rounded-full bg-neutral-300 hover:scale-110 
 									transition duration-200 hover:bg-opacity-80 m-auto bg-opacity-20"
@@ -147,8 +150,10 @@ export default function PreInviteOptions({
                     rounded-3xl p-5 resize-none mb-3 text-center"
 				></textarea>
 				<button
-					className="basis-[10%] bg-green-600 p-2 rounded-full duration-300
-                    hover:scale-[102%] hover:opacity-80 transition text-white text-xl text-center"
+					disabled={Boolean(maxLimit)}
+					className={`basis-[10%] bg-green-600 p-2 rounded-full duration-300
+                    hover:scale-[102%] hover:opacity-80 transition text-white text-xl text-center
+					${maxLimit ? "bg-neutral-400" : null}`}
 					onClick={handleOnClick}
 				>
 					Send Invite

--- a/Client/src/lib/defaults/Default.ts
+++ b/Client/src/lib/defaults/Default.ts
@@ -44,12 +44,14 @@ export const defaultMinesConfig: MinesConfigType = {
 	},
 };
 
-export const defaultGridSize = 6;
+export const defaultGridSizeInput = 6;
+
+export const defaultGridSize = 36;
 
 export const initialInviteMessage: InviteMessageType = {
 	message: "",
 	gameOptions: {
-		gridSize: defaultGridSize * defaultGridSize,
+		gridSize: defaultGridSize,
 		minesConfig: defaultMinesConfig,
 	},
 	ready: false,

--- a/Client/src/pages/Menu.tsx
+++ b/Client/src/pages/Menu.tsx
@@ -13,7 +13,7 @@ export default function Menu() {
         bg-gradient-to-t from-transparent to-slate-700"
 		>
 			<div
-				className="absolute top-0 botom-0 left-0 right-0 -z-10 bg-cover blur-sm
+				className="absolute top-0 botom-0 left-0 right-0 -z-10 bg-cover bg-center blur-sm
             bg-[url('../public/assets/images/bg.png')] flex-1 h-screen opacity-50"
 			/>
 			<RequestReceiver />


### PR DESCRIPTION
Main changes:
- implemented send invite guarding using maxLimit state
- ability to send invite without putting any text
- total mines count with "exceeded" state / "max" state / normal state

Details:
- changed maxLimit from boolean to 0,1,2 state
  1. maxLimit = 0, under maximum
  2. maxLimit = 1, at maximum
  3. maxLimit = 2, went over maximum
- added defaultGridSize (ex: 36 blocks) and defaultGridSizeInput (ex: 6)  in defaults
- replaced old defaultGridSize with defaultGridSizeInput
- maxDisabled prop added in IncrementDecrementButton (optional)
- switched places of increment and decrement button (+ -) -> (- +)
- new GridSizeButton component (a more specific version of IncrementDecrementButton)
- changed from using gridSize from HTMLInputRef to using react state
- FoundMinesEffect are modified to be faster and the text to have more 3d feel (purpose is to add contrast with the colored blocks)