### PR TITLE
Bug fix/matching invitation chat

### DIFF
--- a/Client/src/components/Chat.tsx
+++ b/Client/src/components/Chat.tsx
@@ -7,7 +7,7 @@ import AutoScroll from "@brianmcallister/react-auto-scroll";
 import { getUserColor } from "../lib/utility/GetUserColor";
 import format from "date-fns/format";
 
-export default function Chat() {
+export default function Chat({ mode }: { mode: string }) {
     const { global_state } = React.useContext(GlobalContext);
     const { name, gameInfo, activeUsers } = global_state;
     const { socket } = React.useContext(SocketContext);
@@ -26,13 +26,30 @@ export default function Chat() {
     }, []);
     React.useEffect(() => {
         if (socket !== undefined) {
-            socket.on("chat update", (chat: Array<MessageType>) => {
-                setChat(chat);
-            });
             socket.emit("chat request", {
                 name: name,
                 roomID: gameInfo.roomID,
             });
+            socket.on(
+                "chat update",
+                (chat: { [key: string]: Array<MessageType> }) => {
+                    console.log(chat);
+                    if (mode === "local" && chat.local !== undefined) {
+                        setChat(chat.local);
+                    } else if (mode === "global" && chat.global !== undefined) {
+                        setChat(chat.global);
+                    } else {
+                        setTimeout(
+                            () =>
+                                socket.emit("chat request", {
+                                    name: name,
+                                    roomID: gameInfo.roomID,
+                                }),
+                            100
+                        );
+                    }
+                }
+            );
             return () => socket.off("chat update") as any;
         }
     }, [socket, gameInfo.roomID, activeUsers]);

--- a/Client/src/components/Chat.tsx
+++ b/Client/src/components/Chat.tsx
@@ -33,7 +33,6 @@ export default function Chat({ mode }: { mode: string }) {
             socket.on(
                 "chat update",
                 (chat: { [key: string]: Array<MessageType> }) => {
-                    console.log(chat);
                     if (mode === "local" && chat.local !== undefined) {
                         setChat(chat.local);
                     } else if (mode === "global" && chat.global !== undefined) {

--- a/Client/src/components/ExtraButtons.tsx
+++ b/Client/src/components/ExtraButtons.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { playAudio } from "../lib/utility/Audio";
+import { NavigateContext } from "../lib/utility/Navigate";
+import { GlobalContext } from "../states";
+import { PersistentFlagsType } from "../types";
+
+const ExtraButtons = () => {
+    const { global_state, dispatch } = React.useContext(GlobalContext);
+    const { persistentFlags } = global_state;
+    const { navigate } = React.useContext(NavigateContext);
+    const handleOnClickHowToPlay = () => {
+        const newPersistentFlags: PersistentFlagsType = {
+            ...persistentFlags,
+            howToPlayIsActive: !persistentFlags.howToPlayIsActive,
+        };
+        dispatch({
+            type: "set",
+            field: "persistentFlags",
+            payload: newPersistentFlags,
+        });
+        playAudio("pop.wav");
+    };
+    const handleOnClickExit = () => {
+        navigate("root");
+        playAudio("pop.wav");
+    };
+    return (
+        <div className="absolute flex top-2 right-3 w-fit">
+            <button
+                onClick={handleOnClickHowToPlay}
+                className="w-11 h-11 hover:scale-110 opacity-70 z-30 transition mx-2"
+            >
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 512 512"
+                    className="fill-white"
+                >
+                    <path d="M256 0C114.6 0 0 114.6 0 256s114.6 256 256 256s256-114.6 256-256S397.4 0 256 0zM256 464c-114.7 0-208-93.31-208-208S141.3 48 256 48s208 93.31 208 208S370.7 464 256 464zM256 336c-18 0-32 14-32 32s13.1 32 32 32c17.1 0 32-14 32-32S273.1 336 256 336zM289.1 128h-51.1C199 128 168 159 168 198c0 13 11 24 24 24s24-11 24-24C216 186 225.1 176 237.1 176h51.1C301.1 176 312 186 312 198c0 8-4 14.1-11 18.1L244 251C236 256 232 264 232 272V288c0 13 11 24 24 24S280 301 280 288V286l45.1-28c21-13 34-36 34-60C360 159 329 128 289.1 128z" />
+                </svg>
+            </button>
+            <button
+                onClick={handleOnClickExit}
+                className="w-11 h-11 hover:scale-110 opacity-70 z-30 transition mx-2"
+            >
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 576 512"
+                    className="fill-white"
+                >
+                    <path d="M320 32c0-9.9-4.5-19.2-12.3-25.2S289.8-1.4 280.2 1l-179.9 45C79 51.3 64 70.5 64 92.5V448H32c-17.7 0-32 14.3-32 32s14.3 32 32 32H96 288h32V480 32zM256 256c0 17.7-10.7 32-24 32s-24-14.3-24-32s10.7-32 24-32s24 14.3 24 32zm96-128h96V480v32h32 64c17.7 0 32-14.3 32-32s-14.3-32-32-32H512V128c0-35.3-28.7-64-64-64H352v64z" />
+                </svg>
+            </button>
+        </div>
+    );
+};
+
+export default ExtraButtons;

--- a/Client/src/components/HowToPlay.tsx
+++ b/Client/src/components/HowToPlay.tsx
@@ -38,6 +38,9 @@ const HowToPlay = () => {
         }
     };
     //init visible state through function
+    React.useEffect(() => {
+        setCurrentPage(0);
+    }, [persistentFlags.howToPlayIsActive]);
     React.useLayoutEffect(() => {
         if (visible === null) {
             setVisible(getVisibleState());

--- a/Client/src/components/Result.tsx
+++ b/Client/src/components/Result.tsx
@@ -5,10 +5,9 @@ import { SocketContext } from "../socket";
 import { playAudio } from "../lib/utility/Audio";
 import { NavigateContext } from "../lib/utility/Navigate";
 import Countdown from "./Countdown";
-import { PersistentFlagsType } from "../types";
 
 export default function Result() {
-    const { global_state, dispatch } = React.useContext(GlobalContext);
+    const { global_state } = React.useContext(GlobalContext);
     const { socket } = React.useContext(SocketContext);
     const { navigate } = React.useContext(NavigateContext);
     const { persistentFlags, gameInfo, name } = global_state;
@@ -35,14 +34,19 @@ export default function Result() {
         }
     };
     const checkWinner = (name: string) => {
-        return getWinner() === name;
+        const res = getWinner();
+        return res === undefined ? undefined : res === name;
     };
     const getWinner = () => {
         //if other user left mid-way
         if (persistentFlags.userLeft) {
             return name;
         } else {
-            return scores[0] > scores[1] ? users[0].name : users[1].name;
+            return scores[0] > scores[1]
+                ? users[0].name
+                : scores[0] < scores[1]
+                ? users[1].name
+                : undefined;
         }
     };
     React.useEffect(() => {
@@ -59,12 +63,23 @@ export default function Result() {
             <div className="m-auto w-[70%]">
                 <div
                     className={`font-righteous text-5xl
-                ${checkWinner(name) ? "text-green-400" : "text-red-400"} `}
+                ${
+                    checkWinner(name) === undefined
+                        ? "text-yellow-400"
+                        : checkWinner(name)
+                        ? "text-green-400"
+                        : "text-red-400"
+                } `}
                 >
-                    {checkWinner(name) ? "VICTORY!" : "DEFEAT!"}
+                    {checkWinner(name) === undefined
+                        ? "DRAW!"
+                        : checkWinner(name)
+                        ? "VICTORY!"
+                        : "DEFEAT!"}
                 </div>
                 <div className="text-cyan-300 text-2xl">
-                    {getWinner().toUpperCase()} WINS!
+                    {getWinner()?.toUpperCase()}{" "}
+                    {getWinner() !== undefined ? "WINS!" : null}
                 </div>
                 {!persistentFlags.userLeft && (
                     <>

--- a/Client/src/pages/Game.tsx
+++ b/Client/src/pages/Game.tsx
@@ -106,7 +106,7 @@ export default function Game() {
                         </div>
                         <div className="flex flex-col basis-[30%] m-auto relative">
                             <div className="w-[90%] bg-zinc-600 h-[70vh] bg-opacity-70 p-5 rounded-3xl m-auto">
-                                <Chat />
+                                <Chat mode="local" />
                             </div>
                             <SurrenderButton />
                             <ConfettiButton />

--- a/Client/src/pages/Game.tsx
+++ b/Client/src/pages/Game.tsx
@@ -17,6 +17,8 @@ import PauseButton from "../components/PauseButton";
 import Pause from "../components/Pause";
 import { NavigateContext } from "../lib/utility/Navigate";
 import { FlagsType } from "../types";
+import ExtraButtons from "../components/ExtraButtons";
+import HowToPlay from "../components/HowToPlay";
 
 export default function Game() {
     const { global_state, dispatch } = React.useContext(GlobalContext);
@@ -37,8 +39,10 @@ export default function Game() {
                     />
                     <Result />
                     <Pause />
+                    <HowToPlay />
                     <Backdrop />
                     <Confetti />
+                    <ExtraButtons />
                     <Confirmation
                         title="Are you sure you wish to surrender?"
                         content="You will lose and leave the game room immediately"

--- a/Client/src/pages/Menu.tsx
+++ b/Client/src/pages/Menu.tsx
@@ -6,10 +6,9 @@ import ReplyReceiver from "../components/ReplyReceiver";
 import MatchingButton from "../components/MatchingButton";
 import SocketID from "../components/SocketID";
 import HowToPlay from "../components/HowToPlay";
-import { NavigateContext } from "../lib/utility/Navigate";
+import ExtraButtons from "../components/ExtraButtons";
 
 export default function Menu() {
-    const { navigate } = React.useContext(NavigateContext);
     return (
         <div
             className="flex flex-col h-screen overflow-hidden text-center font-quicksand
@@ -22,18 +21,7 @@ export default function Menu() {
             <RequestReceiver />
             <ReplyReceiver />
             <HowToPlay />
-            <button
-                onClick={() => navigate("root")}
-                className="absolute w-11 h-11 top-2 right-3 hover:scale-110 opacity-70 z-30 transition"
-            >
-                <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 576 512"
-                    className="fill-white"
-                >
-                    <path d="M320 32c0-9.9-4.5-19.2-12.3-25.2S289.8-1.4 280.2 1l-179.9 45C79 51.3 64 70.5 64 92.5V448H32c-17.7 0-32 14.3-32 32s14.3 32 32 32H96 288h32V480 32zM256 256c0 17.7-10.7 32-24 32s-24-14.3-24-32s10.7-32 24-32s24 14.3 24 32zm96-128h96V480v32h32 64c17.7 0 32-14.3 32-32s-14.3-32-32-32H512V128c0-35.3-28.7-64-64-64H352v64z" />
-                </svg>
-            </button>
+            <ExtraButtons />
             <div className="text-5xl font-righteous text-white drop-shadow-[5px_5px_0px_rgba(30,30,30,1)] pt-5">
                 FIND MY MINES
             </div>

--- a/Client/src/pages/Menu.tsx
+++ b/Client/src/pages/Menu.tsx
@@ -57,7 +57,7 @@ export default function Menu() {
                         CHAT
                     </div>
                     <div className="h-full bg-zinc-600 bg-opacity-80 p-5 rounded-3xl shadow-md">
-                        <Chat />
+                        <Chat mode="global" />
                     </div>
                 </div>
             </div>

--- a/Client/src/socket.tsx
+++ b/Client/src/socket.tsx
@@ -36,7 +36,8 @@ const events = [
 export const SocketProvider = ({ children }: { children: React.ReactNode }) => {
     const { global_state, dispatch } = React.useContext(GlobalContext);
     const { navigate } = React.useContext(NavigateContext);
-    const { gameInfo, name, flags, persistentFlags } = global_state;
+    const { gameInfo, name, flags, persistentFlags, activeUsers } =
+        global_state;
     const [socket, setSocket] = React.useState<Socket | undefined>(undefined);
     const [reconnectInGame, setReconnectInGame] =
         React.useState<boolean>(false);
@@ -53,7 +54,9 @@ export const SocketProvider = ({ children }: { children: React.ReactNode }) => {
                     socket.emit("name register", {
                         name: name,
                         id: socket.id,
-                        inGame: false,
+                        inGame: activeUsers.find(
+                            (user: UserType) => user.name === name
+                        )?.inGame,
                     });
                 }
             });
@@ -263,7 +266,7 @@ export const SocketProvider = ({ children }: { children: React.ReactNode }) => {
             socket.emit("reconnect game", { roomID: gameInfo.roomID });
             setReconnectInGame(false);
         }
-    }, [reconnectInGame, flags.activeUsersInitialized]);
+    }, [reconnectInGame, flags.activeUsersInitialized, gameInfo.roomID]);
     return (
         <SocketContext.Provider
             value={

--- a/Server/server.js
+++ b/Server/server.js
@@ -475,18 +475,16 @@ socketIO.on("connection", (socket) => {
         }
     });
     socket.on("chat message", ({ msg, name, roomID, }) => {
-        var _a, _b, _c;
+        var _a;
         //server selects and sends the chat history according to user status (online or in-game)
         //chat histories are private (different roomID will not have access to each other's chat history)
         if (((_a = activeUsers[name]) === null || _a === void 0 ? void 0 : _a.inGame) && roomID !== undefined) {
-            console.log("Requester", name, "RETURN LOCAL CHAT", (_b = activeUsers[name]) === null || _b === void 0 ? void 0 : _b.inGame, roomID);
             chatHistory.local[roomID].push(msg);
             socketIO
                 .to(roomID)
                 .emit("chat update", { local: chatHistory.local[roomID] });
         }
         else {
-            console.log("Requester", name, "RETURN LOCAL CHAT", (_c = activeUsers[name]) === null || _c === void 0 ? void 0 : _c.inGame, roomID);
             chatHistory.global.push(msg);
             const filteredGameInfos = gameInfos.filter((gameInfo) => gameInfo.state === 2);
             socketIO

--- a/Server/server.js
+++ b/Server/server.js
@@ -469,8 +469,9 @@ socketIO.on("connection", (socket) => {
                 .emit("chat update", chatHistory.local[roomID]);
         }
         else {
+            const filteredGameInfos = gameInfos.filter((gameInfo) => gameInfo.state === 2);
             socketIO
-                .except(gameInfos.map((gameInfo) => gameInfo.roomID))
+                .except(filteredGameInfos.map((gameInfo) => gameInfo.roomID))
                 .emit("chat update", chatHistory.global);
         }
     });
@@ -486,8 +487,9 @@ socketIO.on("connection", (socket) => {
         }
         else {
             chatHistory.global.push(msg);
+            const filteredGameInfos = gameInfos.filter((gameInfo) => gameInfo.state === 2);
             socketIO
-                .except(gameInfos.map((gameInfo) => gameInfo.roomID))
+                .except(filteredGameInfos.map((gameInfo) => gameInfo.roomID))
                 .emit("chat update", chatHistory.global);
         }
     });

--- a/Server/server.js
+++ b/Server/server.js
@@ -322,7 +322,7 @@ socketIO.of("/").adapter.on("leave-room", (roomID, id) => {
         const saveUser = Object.keys(activeUsers).find((value) => {
             return activeUsers[value].id === id;
         });
-        //delay for 2 seconds to allow user to reconnect
+        //delay for 1.75 seconds to allow user to reconnect
         setTimeout(() => __awaiter(void 0, void 0, void 0, function* () {
             //checks if the user has reconnected,
             //if not notify other user that they have left
@@ -344,11 +344,10 @@ socketIO.of("/").adapter.on("leave-room", (roomID, id) => {
                 activeGames = activeGames.filter((activeGame) => activeGame.roomID !== info.roomID);
                 cleanGameInfos();
             }
-        }), 1500);
+        }), 1750);
     }
 });
 socketIO.on("connection", (socket) => {
-    ``;
     console.log("Connected!", socket.id, socketIO.of("/").sockets.size);
     socket.on("name probe", (userName) => {
         const nameExists = activeUsers[userName] !== undefined;
@@ -466,31 +465,33 @@ socketIO.on("connection", (socket) => {
         if (((_a = activeUsers[name]) === null || _a === void 0 ? void 0 : _a.inGame) && roomID !== undefined) {
             socketIO
                 .to(roomID)
-                .emit("chat update", chatHistory.local[roomID]);
+                .emit("chat update", { local: chatHistory.local[roomID] });
         }
         else {
             const filteredGameInfos = gameInfos.filter((gameInfo) => gameInfo.state === 2);
             socketIO
                 .except(filteredGameInfos.map((gameInfo) => gameInfo.roomID))
-                .emit("chat update", chatHistory.global);
+                .emit("chat update", { global: chatHistory.global });
         }
     });
     socket.on("chat message", ({ msg, name, roomID, }) => {
-        var _a;
+        var _a, _b, _c;
         //server selects and sends the chat history according to user status (online or in-game)
         //chat histories are private (different roomID will not have access to each other's chat history)
         if (((_a = activeUsers[name]) === null || _a === void 0 ? void 0 : _a.inGame) && roomID !== undefined) {
+            console.log("Requester", name, "RETURN LOCAL CHAT", (_b = activeUsers[name]) === null || _b === void 0 ? void 0 : _b.inGame, roomID);
             chatHistory.local[roomID].push(msg);
             socketIO
                 .to(roomID)
-                .emit("chat update", chatHistory.local[roomID]);
+                .emit("chat update", { local: chatHistory.local[roomID] });
         }
         else {
+            console.log("Requester", name, "RETURN LOCAL CHAT", (_c = activeUsers[name]) === null || _c === void 0 ? void 0 : _c.inGame, roomID);
             chatHistory.global.push(msg);
             const filteredGameInfos = gameInfos.filter((gameInfo) => gameInfo.state === 2);
             socketIO
                 .except(filteredGameInfos.map((gameInfo) => gameInfo.roomID))
-                .emit("chat update", chatHistory.global);
+                .emit("chat update", { global: chatHistory.global });
         }
     });
     socket.on("admin clear chat", () => {

--- a/Server/server.ts
+++ b/Server/server.ts
@@ -566,9 +566,12 @@ socketIO.on("connection", (socket: any) => {
                     .to(roomID)
                     .emit("chat update", chatHistory.local[roomID]);
             } else {
+                const filteredGameInfos = gameInfos.filter(
+                    (gameInfo: GameInfoType) => gameInfo.state === 2
+                );
                 socketIO
                     .except(
-                        gameInfos.map(
+                        filteredGameInfos.map(
                             (gameInfo: GameInfoType) => gameInfo.roomID
                         )
                     )
@@ -596,9 +599,12 @@ socketIO.on("connection", (socket: any) => {
                     .emit("chat update", chatHistory.local[roomID]);
             } else {
                 chatHistory.global.push(msg);
+                const filteredGameInfos = gameInfos.filter(
+                    (gameInfo: GameInfoType) => gameInfo.state === 2
+                );
                 socketIO
                     .except(
-                        gameInfos.map(
+                        filteredGameInfos.map(
                             (gameInfo: GameInfoType) => gameInfo.roomID
                         )
                     )

--- a/Server/server.ts
+++ b/Server/server.ts
@@ -592,25 +592,11 @@ socketIO.on("connection", (socket: any) => {
             //server selects and sends the chat history according to user status (online or in-game)
             //chat histories are private (different roomID will not have access to each other's chat history)
             if (activeUsers[name]?.inGame && roomID !== undefined) {
-                console.log(
-                    "Requester",
-                    name,
-                    "RETURN LOCAL CHAT",
-                    activeUsers[name]?.inGame,
-                    roomID
-                );
                 chatHistory.local[roomID].push(msg);
                 socketIO
                     .to(roomID)
                     .emit("chat update", { local: chatHistory.local[roomID] });
             } else {
-                console.log(
-                    "Requester",
-                    name,
-                    "RETURN LOCAL CHAT",
-                    activeUsers[name]?.inGame,
-                    roomID
-                );
                 chatHistory.global.push(msg);
                 const filteredGameInfos = gameInfos.filter(
                     (gameInfo: GameInfoType) => gameInfo.state === 2

--- a/Server/server.ts
+++ b/Server/server.ts
@@ -364,7 +364,7 @@ socketIO.of("/").adapter.on("leave-room", (roomID: string, id: string) => {
         const saveUser = Object.keys(activeUsers).find((value: string) => {
             return activeUsers[value].id === id;
         });
-        //delay for 2 seconds to allow user to reconnect
+        //delay for 1.75 seconds to allow user to reconnect
         setTimeout(async () => {
             //checks if the user has reconnected,
             //if not notify other user that they have left
@@ -391,12 +391,11 @@ socketIO.of("/").adapter.on("leave-room", (roomID: string, id: string) => {
                 );
                 cleanGameInfos();
             }
-        }, 1500);
+        }, 1750);
     }
 });
 
 socketIO.on("connection", (socket: any) => {
-    ``;
     console.log("Connected!", socket.id, socketIO.of("/").sockets.size);
     socket.on("name probe", (userName: string) => {
         const nameExists = activeUsers[userName] !== undefined;
@@ -564,7 +563,7 @@ socketIO.on("connection", (socket: any) => {
             if (activeUsers[name]?.inGame && roomID !== undefined) {
                 socketIO
                     .to(roomID)
-                    .emit("chat update", chatHistory.local[roomID]);
+                    .emit("chat update", { local: chatHistory.local[roomID] });
             } else {
                 const filteredGameInfos = gameInfos.filter(
                     (gameInfo: GameInfoType) => gameInfo.state === 2
@@ -575,7 +574,7 @@ socketIO.on("connection", (socket: any) => {
                             (gameInfo: GameInfoType) => gameInfo.roomID
                         )
                     )
-                    .emit("chat update", chatHistory.global);
+                    .emit("chat update", { global: chatHistory.global });
             }
         }
     );
@@ -593,11 +592,25 @@ socketIO.on("connection", (socket: any) => {
             //server selects and sends the chat history according to user status (online or in-game)
             //chat histories are private (different roomID will not have access to each other's chat history)
             if (activeUsers[name]?.inGame && roomID !== undefined) {
+                console.log(
+                    "Requester",
+                    name,
+                    "RETURN LOCAL CHAT",
+                    activeUsers[name]?.inGame,
+                    roomID
+                );
                 chatHistory.local[roomID].push(msg);
                 socketIO
                     .to(roomID)
-                    .emit("chat update", chatHistory.local[roomID]);
+                    .emit("chat update", { local: chatHistory.local[roomID] });
             } else {
+                console.log(
+                    "Requester",
+                    name,
+                    "RETURN LOCAL CHAT",
+                    activeUsers[name]?.inGame,
+                    roomID
+                );
                 chatHistory.global.push(msg);
                 const filteredGameInfos = gameInfos.filter(
                     (gameInfo: GameInfoType) => gameInfo.state === 2
@@ -608,7 +621,7 @@ socketIO.on("connection", (socket: any) => {
                             (gameInfo: GameInfoType) => gameInfo.roomID
                         )
                     )
-                    .emit("chat update", chatHistory.global);
+                    .emit("chat update", { global: chatHistory.global });
             }
         }
     );


### PR DESCRIPTION
Main changes:
- fixed chat bug during matching / invitation
- fixed chat bug when refresh during the game
- added draw/tie logic in results
- added how to play button
- grouped how to play and leave into extra buttons ( able to read how to play or leave to name page in-game as well)

Details:
- chat component now accepts mode prop (either global or local) (purpose is to let renderer in client decide which scope of chat to display
- chat from server now sends the message array inside a global or local object (purpose is to let the client know which scope it is in so it can decide whether to show it or not)
- reconnection time changed from 1500 ms -> 1750 ms